### PR TITLE
Restore market_data module and fix fundamental fetch

### DIFF
--- a/data_pipeline/UK_data.py
+++ b/data_pipeline/UK_data.py
@@ -18,7 +18,7 @@ import sys # For system operations
 import sqlite3 # For SQLite database operations
 import time # For time-related functions
 from concurrent.futures import ThreadPoolExecutor, as_completed # For multithreading
-from datetime import datetime # For date handling
+from datetime import datetime, timedelta # For date handling
 from typing import Optional # For type hinting
 from decimal import Decimal, ROUND_HALF_UP, InvalidOperation # For precise decimal rounding
 
@@ -132,7 +132,7 @@ def fetch_fundamental_data(
             info = ticker.info
             key_ratios = {
                 'Ticker': ticker_symbol,
-                'CompanyName': info['longName'],
+                'CompanyName': info.get('longName'),
                 'returnOnEquity': info.get('returnOnEquity'),
                 'grossMargins': info.get('grossMargins'),
                 'operatingMargins': info.get('operatingMargins'),
@@ -149,7 +149,7 @@ def fetch_fundamental_data(
                 'beta': info.get('beta'),
                 'averageVolume': info.get('averageVolume')
             }
-            print("Company Name:", info['longName'])
+            print("Company Name:", info.get('longName'))
             if use_cache:
                 save_fundamentals_cache(ticker_symbol, key_ratios)
             logging.info(f"Fetched fundamentals for {ticker_symbol}")

--- a/data_pipeline/market_data.py
+++ b/data_pipeline/market_data.py
@@ -1,0 +1,58 @@
+"""Compatibility layer exposing market data helpers.
+
+This module re-exports the key functions from ``UK_data`` so that the rest
+of the codebase – and the tests in this kata – can simply ``import
+market_data``.  Historically the functionality lived in a module called
+``market_data`` but it was renamed.  The tests still expect the old name, so
+this thin wrapper restores the original interface without duplicating
+implementation.
+"""
+
+import config
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from tqdm import tqdm
+from UK_data import (
+    load_cached_fundamentals,
+    save_fundamentals_cache,
+    fetch_historical_data,
+    fetch_fundamental_data,
+    combine_price_and_fundamentals,
+)
+from financial_utils import round_financial_columns
+
+__all__ = [
+    "load_cached_fundamentals",
+    "save_fundamentals_cache",
+    "fetch_historical_data",
+    "fetch_fundamental_data",
+    "combine_price_and_fundamentals",
+    "round_financial_columns",
+]
+
+
+def fetch_fundamentals_threaded(tickers: list[str], use_cache: bool = True) -> list[dict]:
+    """Fetch fundamentals for multiple tickers concurrently.
+
+    This re-implementation ensures that ``fetch_fundamental_data`` is looked up
+    from this module so tests can patch it easily.
+    """
+    results: list[dict] = []
+    with ThreadPoolExecutor(max_workers=config.MAX_THREADS) as executor:
+        futures = {
+            executor.submit(fetch_fundamental_data, ticker, use_cache=use_cache): ticker
+            for ticker in tickers
+        }
+        for future in tqdm(as_completed(futures), total=len(futures), desc="Fetching Fundamentals"):
+            ticker = futures[future]
+            try:
+                res = future.result()
+                if res:
+                    results.append(res)
+                else:
+                    logging.warning(f"No data returned for {ticker}")
+            except Exception as exc:
+                logging.error(f"Error fetching data for {ticker}: {exc}")
+    return results
+
+__all__.insert(4, "fetch_fundamentals_threaded")


### PR DESCRIPTION
## Summary
- add a `market_data` compatibility wrapper exporting helpers from `UK_data`
- handle missing `longName` in fundamental fetch and import `timedelta`
- reimplement threaded fundamentals fetch so tests can patch `fetch_fundamental_data`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6895085299a88328a7c6776d91745144