### PR TITLE
Add startup directory checks and cloud storage docs

### DIFF
--- a/data_pipeline/README.md
+++ b/data_pipeline/README.md
@@ -65,6 +65,19 @@ streamlit run streamlit_screener.py
 
 ---
 
+## ☁️ Persistent Storage Recommendations
+For deployments requiring durable storage of datasets or logs, point the
+`DATA_DIR`, `CACHE_DIR`, and `LOG_DIR` environment variables to cloud object
+storage such as:
+
+- **Amazon S3**
+- **Supabase Storage**
+
+These services keep pipeline outputs across restarts and can be mounted or
+accessed via SDKs, allowing the application to treat them like local folders.
+
+---
+
 ## ✅ When Ready for Cloud Deployment
 - Switch to a hosted DB like Supabase/PostgreSQL
 - Consider using an online cache or removing file-based cache

--- a/data_pipeline/cache_utils.py
+++ b/data_pipeline/cache_utils.py
@@ -3,7 +3,10 @@ import json
 import os
 from datetime import datetime, timedelta
 
-CACHE_FILE = "data_pipeline/cache/fundamentals_cache.json"
+import config
+
+
+CACHE_FILE = os.path.join(config.CACHE_DIR, "fundamentals_cache.json")
 
 def load_cache_file():
     if os.path.exists(CACHE_FILE):


### PR DESCRIPTION
## Summary
- ensure data, cache and log directories exist on startup with env var overrides and temp fallbacks
- use config-driven path for cache file
- document cloud storage options for persistent dataset and log directories

## Testing
- `python -m py_compile data_pipeline/config.py data_pipeline/cache_utils.py`
- `PYTHONPATH=data_pipeline pytest` *(fails: ModuleNotFoundError: No module named 'market_data')*

------
https://chatgpt.com/codex/tasks/task_b_68950bfffb7c8328a40ee3b1b45b8a34