### PR TITLE
Use assertIn for missing field test

### DIFF
--- a/data_pipeline/test_err_handling.py
+++ b/data_pipeline/test_err_handling.py
@@ -14,7 +14,7 @@ class TestErrorHandling(unittest.TestCase):
         fundamentals = [{'Ticker': 'ERR.L'}]  # minimal
         combined = market_data.combine_price_and_fundamentals(price_df, fundamentals)
         rounded = market_data.round_financial_columns(combined)
-        self.assertTrue('returnOnEquity' in rounded.columns or True)
+        self.assertIn('returnOnEquity', rounded.columns)
         # Should not crash even with missing fields
 
     def test_bad_data(self):


### PR DESCRIPTION
## Summary
- replace deprecated always-true assertion with `assertIn` for `returnOnEquity` column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'market_data')*

------
https://chatgpt.com/codex/tasks/task_b_68950ca36bb4832889f00fa99fa1b8d5