### PR TITLE
feat: switch database layer to SQLAlchemy engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,22 @@
 
 ---
 
-> 📝 **Note:**  
-> This is a **pre-release** version. The project is under active development.  
+> 📝 **Note:**
+> This is a **pre-release** version. The project is under active development.
 > Phase 2 (Macro Data Integration) is planned in upcoming releases.
+
+### Database configuration
+
+The data pipeline now relies on SQLAlchemy for database access.  Set the
+`DATABASE_URL` environment variable to point to your database before running the
+pipeline.  Any SQLAlchemy-compatible connection string is supported, for
+example:
+
+```bash
+export DATABASE_URL="sqlite:///path/to/stocks_data.db"
+```
+
+If `DATABASE_URL` is not provided a SQLite database named `stocks_data.db` will
+be created inside the pipeline's data directory.
 
 

--- a/data_pipeline/UK_data.py
+++ b/data_pipeline/UK_data.py
@@ -220,7 +220,7 @@ def main(tickers, start_date, end_date, use_cache=True):
     # Save computed factors to DB
     if financial_df is not None:
         financial_tbl = "financial_tbl"
-        Dbhelper = DBHelper(config.DB_PATH)  # Create a new DBHelper instance
+        Dbhelper = DBHelper(config.DATABASE_URL)  # Create a new DBHelper instance
         Dbhelper.create_table(financial_tbl, financial_df) # Create table if not exists
         Dbhelper.insert_dataframe(financial_tbl, financial_df) # Insert computed factors into the table
         Dbhelper.close()

--- a/data_pipeline/analyse_db.py
+++ b/data_pipeline/analyse_db.py
@@ -1,14 +1,15 @@
-import sqlite3
 import pandas as pd
+from sqlalchemy import create_engine
 
+import config
 import logging
-def analyze_db(path):
 
-DB_PATH = "data_pipeline/data/stocks_data.db"
-conn = sqlite3.connect(DB_PATH)
+
+DB_PATH = config.DATABASE_URL
+engine = create_engine(DB_PATH)
 
 # Load a sample of the data
-df = pd.read_sql("SELECT * FROM stock_data", conn)
+df = pd.read_sql("SELECT * FROM stock_data", engine)
 
 # General stats
 print(df.info())
@@ -18,12 +19,12 @@ print(f'describe {df.describe()}')
 print(f' Missing data count {df.isnull().sum()}')
 
 # Check for duplicates
-print(f'duplicates data count {df.duplicated(subset=['Date', 'Ticker']).sum()}')
+print(f"duplicates data count {df.duplicated(subset=['Date', 'Ticker']).sum()}")
 
 # Check data coverage per ticker
-print(f'data coverage per ticker {df['Ticker'].value_counts()}')
+print(f"data coverage per ticker {df['Ticker'].value_counts()}")
 
 # Spot-check for outliers
 print(df[['Close', 'Volume', 'marketCap']].describe(),end='\n\n')
 
-conn.close()
+engine.dispose()

--- a/data_pipeline/config.py
+++ b/data_pipeline/config.py
@@ -4,6 +4,7 @@
 # Importing necessary libraries
 import os
 import tempfile
+from sqlalchemy import create_engine
 
 # ---------------------------------------------------------------------------
 # Directory structure
@@ -35,7 +36,13 @@ def _ensure_dir(env_var: str, default: str) -> str:
 DATA_DIR = _ensure_dir("DATA_DIR", os.path.join("data_pipeline", "data"))
 CACHE_DIR = _ensure_dir("CACHE_DIR", os.path.join("data_pipeline", "cache"))
 LOG_DIR = _ensure_dir("LOG_DIR", os.path.join("data_pipeline", "logs"))
-DB_PATH = os.path.join(DATA_DIR, "stocks_data.db")  # Path to the SQLite database
+DB_PATH = os.path.join(DATA_DIR, "stocks_data.db")  # Default SQLite database location
+
+# Database configuration
+# ``DATABASE_URL`` can point to any database supported by SQLAlchemy.  When not
+# provided we fall back to a local SQLite file inside ``DATA_DIR``.
+DATABASE_URL = os.environ.get("DATABASE_URL", f"sqlite:///{DB_PATH}")
+ENGINE = create_engine(DATABASE_URL)
 
 # Configuration settings
 MAX_RETRIES = 5 # Maximum number of retry attempts for fetching data in case of failure

--- a/data_pipeline/db_utils.py
+++ b/data_pipeline/db_utils.py
@@ -1,53 +1,63 @@
-import sqlite3
+from typing import Optional
+
 import pandas as pd
-import numpy as np
+from sqlalchemy import create_engine, inspect, text
+
+import config
 
 class DBHelper:
-    def __init__(self, db_path):
-        self.conn = sqlite3.connect(db_path)
-        self.cur = self.conn.cursor()
+    """Simple helper around a SQLAlchemy engine.
 
-    def create_table(self, table_name,df):
+    Parameters
+    ----------
+    db_url: Optional[str]
+        Database connection string.  When not provided the value from
+        :mod:`config` (``config.DATABASE_URL``) is used.
+    """
+
+    def __init__(self, db_url: Optional[str] = None):
+        self.database_url = db_url or config.DATABASE_URL
+        self.engine = create_engine(self.database_url)
+
+    def create_table(self, table_name, df):
         dtype_map = self.df_sql_dtypes(df)
-        cols_sql = ',\n  '.join([f'"{col}" {dtype}' for col, dtype in dtype_map.items()])    
-        sql = f"CREATE TABLE IF NOT EXISTS {table_name} ({cols_sql})"
-        self.cur.execute(sql)
-        self.conn.commit()
+        cols_sql = ',\n  '.join([f'"{col}" {dtype}' for col, dtype in dtype_map.items()])
+        sql = text(f"CREATE TABLE IF NOT EXISTS {table_name} ({cols_sql})")
+        with self.engine.begin() as conn:
+            conn.execute(sql)
 
         # --- Add missing columns if table already exists ---
-        self.cur.execute(f"PRAGMA table_info({table_name})")
-        existing_cols = set(row[1] for row in self.cur.fetchall())
+        inspector = inspect(self.engine)
+        existing_cols = set(col['name'] for col in inspector.get_columns(table_name))
         for col, dtype in dtype_map.items():
             if col not in existing_cols:
-                alter_sql = f'ALTER TABLE {table_name} ADD COLUMN "{col}" {dtype}'
-                self.cur.execute(alter_sql)
-                self.conn.commit()
+                alter_sql = text(f'ALTER TABLE {table_name} ADD COLUMN "{col}" {dtype}')
+                with self.engine.begin() as conn:
+                    conn.execute(alter_sql)
 
 
     def insert_row(self, table_name, row_dict):
-        # row_dict = {"col1": val1, "col2": val2, ...}
         cols = ", ".join(row_dict.keys())
-        placeholders = ", ".join(["?"] * len(row_dict))
-        values = tuple(row_dict.values())
-        sql = f"INSERT INTO {table_name} ({cols}) VALUES ({placeholders})"
-        self.cur.execute(sql, values)
-        self.conn.commit()
+        placeholders = ", ".join([f":{col}" for col in row_dict])
+        sql = text(f"INSERT INTO {table_name} ({cols}) VALUES ({placeholders})")
+        with self.engine.begin() as conn:
+            conn.execute(sql, row_dict)
 
     def insert_dataframe(self, table_name, df):
-        df.to_sql(table_name, self.conn, if_exists='replace', index=False)
+        df.to_sql(table_name, self.engine, if_exists='replace', index=False)
 
     def close(self):
-        self.conn.close()
+        self.engine.dispose()
 
     def df_sql_dtypes(self,df):
         """
-        Create a dictionary mapping DataFrame column names to SQLite types.
-        Float/Int → 'REAL', everything else → 'TEXT'
+        Create a dictionary mapping DataFrame column names to SQL types.
+        Float/Int → 'FLOAT', everything else → 'TEXT'
         """
         type_map = {}
         for col in df.columns:
             if pd.api.types.is_numeric_dtype(df[col]):
-                type_map[col] = 'REAL'
+                type_map[col] = 'FLOAT'
             else:
                 type_map[col] = 'TEXT'
         return type_map

--- a/data_pipeline/streamlit_screener.py
+++ b/data_pipeline/streamlit_screener.py
@@ -1,7 +1,9 @@
 import streamlit as st
 import pandas as pd
-import sqlite3
 import numpy as np
+from sqlalchemy import create_engine
+
+import config
 
 st.set_page_config(page_title="InvestWiseUK Multi-Factor Screener", layout="wide")
 
@@ -9,10 +11,9 @@ st.title("📊 InvestWiseUK Multi-Factor Stock Screener")
 
 @st.cache_data
 def load_data():
-    DB_PATH = "data_pipeline/data/stocks_data.db"
-    conn = sqlite3.connect(DB_PATH)
-    df = pd.read_sql("SELECT * FROM financial_tbl", conn)
-    conn.close()
+    engine = create_engine(config.DATABASE_URL)
+    df = pd.read_sql("SELECT * FROM financial_tbl", engine)
+    engine.dispose()
     # Clean NaNs/infs
     for col in ['factor_composite', 'return_12m', 'earnings_yield', 'norm_quality_score']:
         if col in df.columns:

--- a/data_pipeline/test_data.py
+++ b/data_pipeline/test_data.py
@@ -137,7 +137,8 @@ class TestPipelineAdvanced(unittest.TestCase):
 class TestDBHelper(unittest.TestCase):
     def setUp(self):
         self.test_db = "test_stocks.db"
-        self.helper = DBHelper(self.test_db)
+        self.db_url = f"sqlite:///{self.test_db}"
+        self.helper = DBHelper(self.db_url)
         self.df = pd.DataFrame({
             "Ticker": ["A.L", "B.L"],
             "Close": [100, 200],
@@ -152,7 +153,7 @@ class TestDBHelper(unittest.TestCase):
         self.helper.create_table("test_tbl", self.df)
         self.helper.insert_dataframe("test_tbl", self.df)
         # Read back to check
-        result = pd.read_sql("SELECT * FROM test_tbl", self.helper.conn)
+        result = pd.read_sql("SELECT * FROM test_tbl", self.helper.engine)
         self.assertEqual(len(result), 2)
         self.assertIn("Close", result.columns)
         

--- a/data_pipeline/test_full_pipeline.py
+++ b/data_pipeline/test_full_pipeline.py
@@ -38,10 +38,11 @@ class TestFullPipeline(unittest.TestCase):
         factors = compute_factors(rounded)
         # Save to temp DB
         dbfile = "test_pipeline.db"
-        helper = DBHelper(dbfile)
+        db_url = f"sqlite:///{dbfile}"
+        helper = DBHelper(db_url)
         helper.create_table("factors", factors)
         helper.insert_dataframe("factors", factors)
-        readback = pd.read_sql("SELECT * FROM factors", helper.conn)
+        readback = pd.read_sql("SELECT * FROM factors", helper.engine)
         self.assertEqual(len(readback), len(factors))
         helper.close()
         import os


### PR DESCRIPTION
## Summary
- Replace direct sqlite3 usage with SQLAlchemy engine across the pipeline
- Configure database connection via `DATABASE_URL` environment variable
- Update helper utilities, Streamlit screener and analysis script for engine-based access
- Document `DATABASE_URL` connection string format in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68951379a6608328b1521d6d0eb3e317