### PR TITLE
Add Streamlit entrypoint for easier deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,16 @@ export DATABASE_URL="sqlite:///path/to/stocks_data.db"
 If `DATABASE_URL` is not provided a SQLite database named `stocks_data.db` will
 be created inside the pipeline's data directory.
 
+### Running the Streamlit Screener
+
+An interactive stock screener is available via Streamlit. Run it from the
+project root with:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+On Streamlit Community Cloud, set the app's entry point to `streamlit_app.py`
+to launch the screener without extra path configuration.
+
 

--- a/data_pipeline/README.md
+++ b/data_pipeline/README.md
@@ -47,10 +47,14 @@ python UK_data.py --start_date 2020-01-01 --end_date 2025-07-17
 ---
 
 ## ✅ Running the Streamlit Screener Locally
-From inside `data_pipeline/` folder:
+From the project root:
 ```
-streamlit run streamlit_screener.py
+streamlit run streamlit_app.py
 ```
+
+This wrapper imports `data_pipeline.streamlit_screener` so the app can be
+deployed easily on services like Streamlit Community Cloud. Set the app's entry
+point to `streamlit_app.py` when deploying there.
 
 - 🎛️ Use sidebar filters to refine your stock list
 - 📈 View multi-factor rankings and charts

--- a/data_pipeline/streamlit_screener.py
+++ b/data_pipeline/streamlit_screener.py
@@ -3,7 +3,10 @@ import pandas as pd
 import numpy as np
 from sqlalchemy import create_engine
 
-import config
+try:
+    from . import config
+except ImportError:  # fallback when run as a script
+    import config
 
 st.set_page_config(page_title="InvestWiseUK Multi-Factor Screener", layout="wide")
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,3 @@
+"""Entry point for running the Streamlit screener from the project root."""
+
+from data_pipeline import streamlit_screener  # noqa: F401


### PR DESCRIPTION
## Summary
- add `streamlit_app.py` as root Streamlit entrypoint
- update docs to reference new entrypoint and Streamlit Cloud usage
- ensure screener imports config correctly when launched from project root

## Testing
- `pytest` *(fails: AssertionError: 'returnOnEquity' not found)*

------
https://chatgpt.com/codex/tasks/task_b_689dc03739988328a07bfb96b61caf2f