### PR TITLE
Use Streamlit secrets for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Thumbs.db
 token.json
 .vscode/
 .idea/
+.streamlit/secrets.toml

--- a/.streamlit/secrets.example.toml
+++ b/.streamlit/secrets.example.toml
@@ -1,0 +1,8 @@
+# Copy this file to .streamlit/secrets.toml and update with your own values
+# Example Streamlit secrets configuration
+
+# Database connection string
+DATABASE_URL = "postgresql://user:password@host:5432/database"
+
+# API keys
+QUANDL_API_KEY = "your-quandl-api-key"

--- a/README.md
+++ b/README.md
@@ -10,18 +10,24 @@
 > This is a **pre-release** version. The project is under active development.
 > Phase 2 (Macro Data Integration) is planned in upcoming releases.
 
-### Database configuration
+### Secrets configuration
 
-The data pipeline now relies on SQLAlchemy for database access.  Set the
-`DATABASE_URL` environment variable to point to your database before running the
-pipeline.  Any SQLAlchemy-compatible connection string is supported, for
-example:
+Streamlit's secrets mechanism is used for values such as database connection
+strings and API keys. Start by copying the example secrets file:
 
 ```bash
-export DATABASE_URL="sqlite:///path/to/stocks_data.db"
+cp .streamlit/secrets.example.toml .streamlit/secrets.toml
 ```
 
-If `DATABASE_URL` is not provided a SQLite database named `stocks_data.db` will
-be created inside the pipeline's data directory.
+Edit `.streamlit/secrets.toml` and fill in your own values. At a minimum set
+`DATABASE_URL` (e.g. `postgresql://user:password@host:5432/database`) and any
+required API keys like `QUANDL_API_KEY`.
+
+When deploying to Streamlit Cloud, open the app's **⚙️ Settings → Secrets** and
+paste the contents of your local `secrets.toml`.
+
+The data pipeline reads the connection string using
+`st.secrets["DATABASE_URL"]`. If it is not provided a SQLite database named
+`stocks_data.db` will be created inside the pipeline's data directory.
 
 

--- a/data_pipeline/Macro_data.py
+++ b/data_pipeline/Macro_data.py
@@ -1,9 +1,17 @@
 import quandl
 import pandas as pd
+import streamlit as st
+
+try:
+    DEFAULT_API_KEY = st.secrets["QUANDL_API_KEY"]
+except Exception:
+    DEFAULT_API_KEY = None
 
 class FiveYearMacroDataLoader:
-    def __init__(self, api_key, start_date="2020-01-01", end_date="2025-01-01"):
-        self.api_key = api_key
+    def __init__(self, api_key: str | None = None,
+                 start_date: str = "2020-01-01",
+                 end_date: str = "2025-01-01"):
+        self.api_key = api_key or DEFAULT_API_KEY
         quandl.ApiConfig.api_key = self.api_key
         self.start_date = start_date
         self.end_date = end_date
@@ -43,8 +51,7 @@ class FiveYearMacroDataLoader:
             return None
 
 if __name__ == "__main__":
-    API_KEY = "pXBknNEt9LEV6DRBnfhs"  # Replace with your valid Quandl API key
-    loader = FiveYearMacroDataLoader(API_KEY)
+    loader = FiveYearMacroDataLoader()
 
     macro_data = loader.get_combined_macro_data()
     if macro_data is not None:

--- a/data_pipeline/config.py
+++ b/data_pipeline/config.py
@@ -4,6 +4,7 @@
 # Importing necessary libraries
 import os
 import tempfile
+import streamlit as st
 from sqlalchemy import create_engine
 
 # ---------------------------------------------------------------------------
@@ -41,7 +42,10 @@ DB_PATH = os.path.join(DATA_DIR, "stocks_data.db")  # Default SQLite database lo
 # Database configuration
 # ``DATABASE_URL`` can point to any database supported by SQLAlchemy.  When not
 # provided we fall back to a local SQLite file inside ``DATA_DIR``.
-DATABASE_URL = os.environ.get("DATABASE_URL", f"sqlite:///{DB_PATH}")
+try:
+    DATABASE_URL = st.secrets["DATABASE_URL"]
+except Exception:
+    DATABASE_URL = f"sqlite:///{DB_PATH}"
 ENGINE = create_engine(DATABASE_URL)
 
 # Configuration settings


### PR DESCRIPTION
## Summary
- add example `.streamlit/secrets.example.toml` with placeholders for `DATABASE_URL` and `QUANDL_API_KEY`
- document copying the example to `secrets.toml` and managing secrets in Streamlit Cloud
- load `DATABASE_URL` and API keys from `st.secrets` instead of environment variables

## Testing
- `python -m py_compile data_pipeline/config.py data_pipeline/Macro_data.py`
- `pytest` *(fails: TestErrorHandling::test_missing_fields)*

------
https://chatgpt.com/codex/tasks/task_b_689dc0347bec8328ae221053c915b924