### PR TITLE
Add configurable remote cache backend

### DIFF
--- a/data_pipeline/README.md
+++ b/data_pipeline/README.md
@@ -59,7 +59,11 @@ streamlit run streamlit_screener.py
 ---
 
 ## ✅ Notes on Cache & Data Persistence
-- Local JSON cache used for fundamentals (`cache_utils.py`)
+- Cache backend configurable via environment variables:
+  - `CACHE_BACKEND` – `local` (default), `redis` or `s3`
+  - `CACHE_REDIS_URL` – Redis connection string when using the Redis backend
+  - `CACHE_S3_BUCKET` / `CACHE_S3_PREFIX` – S3 bucket (and optional key prefix)
+- Local JSON cache is used when `CACHE_BACKEND` is `local` (`cache_utils.py`)
 - SQLite database stores computed financials (`data/stocks_data.db`)
 - Gmail alerts use credentials from `credentials.json` (optional)
 

--- a/data_pipeline/cache_utils.py
+++ b/data_pipeline/cache_utils.py
@@ -1,46 +1,119 @@
+"""Utilities for caching fundamental data.
+
+The caching layer supports multiple backends controlled by
+``config.CACHE_BACKEND``:
+
+* ``local`` – JSON file stored under ``CACHE_DIR``.
+* ``redis`` – Redis instance referenced by ``CACHE_REDIS_URL``.
+* ``s3`` – Amazon S3 bucket defined by ``CACHE_S3_BUCKET``.
+
+Remote backends may raise exceptions (e.g. connection errors).  Callers are
+expected to handle such failures gracefully.
+"""
 
 import json
 import os
 from datetime import datetime, timedelta
+from typing import Dict
 
 import config
 
 
 CACHE_FILE = os.path.join(config.CACHE_DIR, "fundamentals_cache.json")
 
-def load_cache_file():
+# ---------------------------------------------------------------------------
+# Backend clients
+# ---------------------------------------------------------------------------
+if config.CACHE_BACKEND == "redis":
+    import redis  # type: ignore
+
+    _client = redis.Redis.from_url(config.CACHE_REDIS_URL)
+    _key = "fundamentals_cache"
+elif config.CACHE_BACKEND == "s3":
+    import boto3  # type: ignore
+
+    _client = boto3.client("s3")
+    _key = (
+        os.path.join(config.CACHE_S3_PREFIX, "fundamentals_cache.json")
+        if config.CACHE_S3_PREFIX
+        else "fundamentals_cache.json"
+    )
+else:  # local file backend
+    _client = None
+    _key = CACHE_FILE
+
+
+def _load_cache() -> Dict:
+    """Load the full cache from the configured backend."""
+
+    if config.CACHE_BACKEND == "redis":
+        data = _client.get(_key)
+        return json.loads(data) if data else {}
+    if config.CACHE_BACKEND == "s3":
+        try:
+            obj = _client.get_object(Bucket=config.CACHE_S3_BUCKET, Key=_key)
+            return json.loads(obj["Body"].read().decode("utf-8"))
+        except _client.exceptions.NoSuchKey:
+            return {}
     if os.path.exists(CACHE_FILE):
-        with open(CACHE_FILE, 'r') as f:
+        with open(CACHE_FILE, "r") as f:
             return json.load(f)
     return {}
 
-def save_fundamentals_cache(ticker, data):
-    cache = load_cache_file()
-    cache[ticker] = {
-        "data": data,
-        "timestamp": datetime.utcnow().isoformat()
-    }
-    with open(CACHE_FILE, 'w') as f:
-        json.dump(cache, f, indent=4)
 
-def load_cached_fundamentals(ticker, expiry_minutes=1440):
-    cache = load_cache_file()
-    if ticker in cache:
-        cached_entry = cache[ticker]
-        timestamp = datetime.fromisoformat(cached_entry['timestamp'])
-        if datetime.utcnow() - timestamp < timedelta(minutes=expiry_minutes):
-            return cached_entry['data']
-        else:
-            return None
-    return None
+def _save_cache(cache: Dict) -> None:
+    """Persist the full cache to the configured backend."""
 
-def clear_cached_fundamentals(ticker):
-    cache = load_cache_file()
-    if ticker in cache:
-        del cache[ticker]
-        with open(CACHE_FILE, 'w') as f:
+    if config.CACHE_BACKEND == "redis":
+        _client.set(_key, json.dumps(cache))
+    elif config.CACHE_BACKEND == "s3":
+        _client.put_object(
+            Bucket=config.CACHE_S3_BUCKET,
+            Key=_key,
+            Body=json.dumps(cache).encode("utf-8"),
+        )
+    else:
+        with open(CACHE_FILE, "w") as f:
             json.dump(cache, f, indent=4)
 
-def clear_all_cache():
-    if os.path.exists(CACHE_FILE):
-        os.remove(CACHE_FILE)
+
+def load_cached_fundamentals(ticker: str, expiry_minutes: int = config.CACHE_EXPIRY_MINUTES):
+    """Return cached fundamentals for ``ticker`` if present and fresh."""
+
+    cache = _load_cache()
+    cached_entry = cache.get(ticker)
+    if cached_entry:
+        timestamp = datetime.fromisoformat(cached_entry["timestamp"])
+        if datetime.utcnow() - timestamp < timedelta(minutes=expiry_minutes):
+            return cached_entry["data"]
+    return None
+
+
+def save_fundamentals_cache(ticker: str, data) -> None:
+    """Store ``data`` for ``ticker`` in the cache."""
+
+    cache = _load_cache()
+    cache[ticker] = {"data": data, "timestamp": datetime.utcnow().isoformat()}
+    _save_cache(cache)
+
+
+def clear_cached_fundamentals(ticker: str) -> None:
+    """Remove ``ticker`` from the cache if present."""
+
+    cache = _load_cache()
+    if ticker in cache:
+        del cache[ticker]
+        _save_cache(cache)
+
+
+def clear_all_cache() -> None:
+    """Clear the entire fundamentals cache."""
+
+    if config.CACHE_BACKEND == "redis":
+        _client.delete(_key)
+    elif config.CACHE_BACKEND == "s3":
+        _client.delete_object(Bucket=config.CACHE_S3_BUCKET, Key=_key)
+    else:
+        if os.path.exists(CACHE_FILE):
+            os.remove(CACHE_FILE)
+

--- a/data_pipeline/config.py
+++ b/data_pipeline/config.py
@@ -44,6 +44,24 @@ DB_PATH = os.path.join(DATA_DIR, "stocks_data.db")  # Default SQLite database lo
 DATABASE_URL = os.environ.get("DATABASE_URL", f"sqlite:///{DB_PATH}")
 ENGINE = create_engine(DATABASE_URL)
 
+# Cache backend configuration
+#
+# The cache system can be backed by different stores.  Set
+# ``CACHE_BACKEND`` to one of:
+#   * ``local`` – use a JSON file in ``CACHE_DIR`` (default)
+#   * ``redis`` – use a Redis instance specified by ``CACHE_REDIS_URL``
+#   * ``s3`` – use an S3 bucket specified by ``CACHE_S3_BUCKET``
+CACHE_BACKEND = os.environ.get("CACHE_BACKEND", "local").lower()
+
+# Redis configuration.  Only used when ``CACHE_BACKEND`` is ``redis``.
+# Example: ``redis://localhost:6379/0``
+CACHE_REDIS_URL = os.environ.get("CACHE_REDIS_URL", "redis://localhost:6379/0")
+
+# S3 configuration.  Only used when ``CACHE_BACKEND`` is ``s3``.
+# ``CACHE_S3_BUCKET`` is required, ``CACHE_S3_PREFIX`` is optional.
+CACHE_S3_BUCKET = os.environ.get("CACHE_S3_BUCKET")
+CACHE_S3_PREFIX = os.environ.get("CACHE_S3_PREFIX", "")
+
 # Configuration settings
 MAX_RETRIES = 5 # Maximum number of retry attempts for fetching data in case of failure
 BACKOFF_FACTOR = 2 # Backoff multiplier to increase delay between retries exponentially

--- a/data_pipeline/financial_utils.py
+++ b/data_pipeline/financial_utils.py
@@ -4,14 +4,14 @@ import pandas as pd
 def financial_round(value, places):
     """
     Rounds a value to the specified number of decimal places using decimal.Decimal for accuracy.
-    If value cannot be converted, returns pd.NA.
+    If value cannot be converted, returns NaN.
     """
     try:
         if pd.isna(value):
-            return pd.NA
+            return float('nan')
         return float(Decimal(str(value)).quantize(Decimal(f'1.{"0"*places}'), rounding=ROUND_HALF_UP))
     except (InvalidOperation, TypeError, ValueError):
-        return pd.NA
+        return float('nan')
 
 def round_financial_columns(df: pd.DataFrame) -> pd.DataFrame:
     """


### PR DESCRIPTION
## Summary
- refactor cache_utils to support Redis or S3 backends with JSON-file fallback
- expose cache backend settings via env vars in config
- guard caching operations in UK_data for graceful remote failures
- ensure numeric rounding uses NaN and populate missing fundamentals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689dc031647c83288028394f2e21e776