### PR TITLE
Harden DB helper against SQL injection

### DIFF
--- a/data_pipeline/db_utils.py
+++ b/data_pipeline/db_utils.py
@@ -1,9 +1,11 @@
 from typing import Optional
 
 import pandas as pd
-from sqlalchemy import create_engine, inspect, text
+from sqlalchemy import (Column, Float, MetaData, Table, Text as SAText,
+                        create_engine, inspect, text)
 
 import config
+
 
 class DBHelper:
     """Simple helper around a SQLAlchemy engine.
@@ -18,30 +20,39 @@ class DBHelper:
     def __init__(self, db_url: Optional[str] = None):
         self.database_url = db_url or config.DATABASE_URL
         self.engine = create_engine(self.database_url)
+        self.preparer = self.engine.dialect.identifier_preparer
+
+    def _quote_identifier(self, identifier: str) -> str:
+        """Safely quote an identifier (e.g., table/column name)."""
+        return self.preparer.quote(identifier)
 
     def create_table(self, table_name, df):
         dtype_map = self.df_sql_dtypes(df)
-        cols_sql = ',\n  '.join([f'"{col}" {dtype}' for col, dtype in dtype_map.items()])
-        sql = text(f"CREATE TABLE IF NOT EXISTS {table_name} ({cols_sql})")
-        with self.engine.begin() as conn:
-            conn.execute(sql)
+        metadata = MetaData()
+        columns = []
+        for col, dtype in dtype_map.items():
+            sql_type = Float if dtype == 'FLOAT' else SAText
+            columns.append(Column(col, sql_type))
+        table = Table(table_name, metadata, *columns)
+        metadata.create_all(self.engine, tables=[table])
 
         # --- Add missing columns if table already exists ---
         inspector = inspect(self.engine)
         existing_cols = set(col['name'] for col in inspector.get_columns(table_name))
         for col, dtype in dtype_map.items():
             if col not in existing_cols:
-                alter_sql = text(f'ALTER TABLE {table_name} ADD COLUMN "{col}" {dtype}')
+                alter_sql = text(
+                    f'ALTER TABLE {self._quote_identifier(table_name)} '
+                    f'ADD COLUMN {self._quote_identifier(col)} {dtype}'
+                )
                 with self.engine.begin() as conn:
                     conn.execute(alter_sql)
 
-
     def insert_row(self, table_name, row_dict):
-        cols = ", ".join(row_dict.keys())
-        placeholders = ", ".join([f":{col}" for col in row_dict])
-        sql = text(f"INSERT INTO {table_name} ({cols}) VALUES ({placeholders})")
+        metadata = MetaData()
+        table = Table(table_name, metadata, autoload_with=self.engine)
         with self.engine.begin() as conn:
-            conn.execute(sql, row_dict)
+            conn.execute(table.insert(), row_dict)
 
     def insert_dataframe(self, table_name, df):
         df.to_sql(table_name, self.engine, if_exists='replace', index=False)

--- a/data_pipeline/test_db_utils.py
+++ b/data_pipeline/test_db_utils.py
@@ -1,0 +1,33 @@
+import unittest
+import pandas as pd
+from sqlalchemy import inspect, text
+
+from db_utils import DBHelper
+
+
+class TestDBHelperSQLInjection(unittest.TestCase):
+    def setUp(self):
+        self.db = DBHelper('sqlite://')
+        with self.db.engine.begin() as conn:
+            conn.execute(text('CREATE TABLE safe_table (id INTEGER)'))
+            conn.execute(text('INSERT INTO safe_table (id) VALUES (1)'))
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_malicious_table_name_does_not_execute(self):
+        df = pd.DataFrame({'col1': [1]})
+        malicious = 'malicious; DROP TABLE safe_table;--'
+        self.db.create_table(malicious, df)
+        self.db.insert_row(malicious, {'col1': 1})
+
+        inspector = inspect(self.db.engine)
+        self.assertIn('safe_table', inspector.get_table_names())
+
+        preparer = self.db.engine.dialect.identifier_preparer
+        quoted = preparer.quote(malicious)
+        with self.db.engine.connect() as conn:
+            count = conn.execute(text('SELECT count(*) FROM safe_table')).scalar()
+            self.assertEqual(count, 1)
+            value = conn.execute(text(f'SELECT col1 FROM {quoted}')).scalar()
+            self.assertEqual(value, 1)


### PR DESCRIPTION
## Summary
- build SQL queries using SQLAlchemy `Table`/`Column` metadata and dialect quoting
- sanitize identifiers via dialect `identifier_preparer`
- cover malicious table name attempts in a new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ddecd9c4083289597319af0474e60