### PR TITLE
Add docs and type hints for compute_factors

### DIFF
--- a/data_pipeline/compute_factors.py
+++ b/data_pipeline/compute_factors.py
@@ -2,7 +2,29 @@ import pandas as pd
 import numpy as np
 import ta
 
-def compute_factors(df):
+
+def compute_factors(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Compute technical, value, quality and liquidity factors for a price
+    and fundamentals :class:`~pandas.DataFrame`.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input data containing at least ``Date``, ``Ticker``, ``Close`` and
+        ``Volume`` columns, plus fundamental fields such as ``trailingPE``,
+        ``priceToBook``, ``returnOnEquity``, ``profitMargins`` and
+        ``marketCap``. Optional columns like ``dividendYield`` and
+        ``priceToSalesTrailing12Months`` are used when available.
+
+    Returns
+    -------
+    pd.DataFrame
+        The original DataFrame with additional columns for momentum,
+        volatility, moving averages, technical indicators (RSI, MACD,
+        Bollinger Bands), value ratios, quality metrics, size/liquidity
+        measures and a composite factor.
+    """
     # --- Momentum ---
     for period, label in zip([21, 63, 126, 252], ['1m', '3m', '6m', '12m']):
         df[f'return_{label}'] = (

--- a/data_pipeline/test_full_pipeline.py
+++ b/data_pipeline/test_full_pipeline.py
@@ -5,6 +5,13 @@ from compute_factors import compute_factors
 import market_data
 from db_utils import DBHelper
 
+
+def test_compute_factors_docstring():
+    """Ensure ``compute_factors`` exposes helpful documentation."""
+    doc = compute_factors.__doc__
+    assert doc is not None
+    assert 'Ticker' in doc and 'momentum' in doc
+
 class TestFullPipeline(unittest.TestCase):
     def setUp(self):
         # Prepare synthetic dataset


### PR DESCRIPTION
## Summary
- add detailed docstring and type hints to `compute_factors`
- test docstring content for `compute_factors`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689dded5f8c4832889f888a38828bf46