### PR TITLE
Add scheduled data refresh workflow

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1,0 +1,26 @@
+name: Update UK data
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-data:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run data refresh
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          QUANDL_API_KEY: ${{ secrets.QUANDL_API_KEY }}
+        run: |
+          python data_pipeline/UK_data.py --years 10

--- a/data_pipeline/UK_data.py
+++ b/data_pipeline/UK_data.py
@@ -255,7 +255,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Fetch historical and fundamental data for FTSE 100 stocks.")
     parser.add_argument('--start_date', type=str, default='2020-01-01', help='Start date for historical data (YYYY-MM-DD)')
     parser.add_argument('--end_date', type=str, default=datetime.today().strftime('%Y-%m-%d'), help='End date for historical data (YYYY-MM-DD)')
-    
+    parser.add_argument('--years', type=int, help='Number of years of historical data to fetch')
+
     args = parser.parse_args()
+    if args.years:
+        end = datetime.today()
+        start = end - timedelta(days=args.years * 365)
+        args.start_date = start.strftime('%Y-%m-%d')
+        args.end_date = end.strftime('%Y-%m-%d')
 
     main(config.FTSE_100_TICKERS, args.start_date, args.end_date)


### PR DESCRIPTION
## Summary
- Add `--years` argument to UK_data pipeline for dynamic date range selection.
- Introduce scheduled GitHub Actions workflow to refresh UK data and update shared database.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689de91656a88328a52598bccc43a0f6