### PR TITLE
Add wrapper and scheduling support for UK data pipeline

### DIFF
--- a/data_pipeline/UK_data.py
+++ b/data_pipeline/UK_data.py
@@ -255,7 +255,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Fetch historical and fundamental data for FTSE 100 stocks.")
     parser.add_argument('--start_date', type=str, default='2020-01-01', help='Start date for historical data (YYYY-MM-DD)')
     parser.add_argument('--end_date', type=str, default=datetime.today().strftime('%Y-%m-%d'), help='End date for historical data (YYYY-MM-DD)')
-    
+    parser.add_argument('--years', type=int, default=None, help='Number of years of data to fetch; overrides start/end dates')
+
     args = parser.parse_args()
+
+    if args.years is not None:
+        end_date = datetime.today()
+        start_date = end_date - timedelta(days=365 * args.years)
+        args.start_date = start_date.strftime('%Y-%m-%d')
+        args.end_date = end_date.strftime('%Y-%m-%d')
 
     main(config.FTSE_100_TICKERS, args.start_date, args.end_date)

--- a/run_uk_data.sh
+++ b/run_uk_data.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Wrapper script to update UK data for the last 10 years
+set -e
+cd "$(dirname "$0")"
+python data_pipeline/UK_data.py --years 10


### PR DESCRIPTION
## Summary
- add `run_uk_data.sh` script to execute UK data pipeline for last 10 years
- enhance `UK_data.py` with `--years` argument to compute date range automatically

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689de918aaf48328a7da2572c16940a4