### PR TITLE
Use relative imports in market_data wrapper

### DIFF
--- a/data_pipeline/market_data.py
+++ b/data_pipeline/market_data.py
@@ -8,18 +8,31 @@ this thin wrapper restores the original interface without duplicating
 implementation.
 """
 
-import config
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
+
 from tqdm import tqdm
-from UK_data import (
-    load_cached_fundamentals,
-    save_fundamentals_cache,
-    fetch_historical_data,
-    fetch_fundamental_data,
-    combine_price_and_fundamentals,
-)
-from financial_utils import round_financial_columns
+
+try:
+    from . import config
+    from .UK_data import (
+        load_cached_fundamentals,
+        save_fundamentals_cache,
+        fetch_historical_data,
+        fetch_fundamental_data,
+        combine_price_and_fundamentals,
+    )
+    from .financial_utils import round_financial_columns
+except ImportError:  # pragma: no cover
+    import config
+    from UK_data import (
+        load_cached_fundamentals,
+        save_fundamentals_cache,
+        fetch_historical_data,
+        fetch_fundamental_data,
+        combine_price_and_fundamentals,
+    )
+    from financial_utils import round_financial_columns
 
 __all__ = [
     "load_cached_fundamentals",


### PR DESCRIPTION
## Summary
- refactor market_data to use relative imports for intra-package modules
- fall back to absolute imports when package context is missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689e1a5fce58832882269df53bfb5281