### PR TITLE
Use relative imports for config

### DIFF
--- a/data_pipeline/cache_utils.py
+++ b/data_pipeline/cache_utils.py
@@ -16,7 +16,7 @@ import os
 from datetime import datetime, timedelta
 from typing import Dict
 
-import config
+from . import config
 
 
 CACHE_FILE = os.path.join(config.CACHE_DIR, "fundamentals_cache.json")

--- a/data_pipeline/db_utils.py
+++ b/data_pipeline/db_utils.py
@@ -4,7 +4,7 @@ import pandas as pd
 from sqlalchemy import (Column, Float, MetaData, Table, Text as SAText,
                         create_engine, inspect, text)
 
-import config
+from . import config
 
 
 class DBHelper:


### PR DESCRIPTION
## Summary
- Use relative imports for `config` within `db_utils` and `cache_utils`

## Testing
- `pytest data_pipeline/test_db_utils.py::TestDBHelperSQLInjection::setUp -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_b_689e1a5fa7488328b2aed03e35dc1930