### PR TITLE
Add data pipeline package initializer

### DIFF
--- a/data_pipeline/__init__.py
+++ b/data_pipeline/__init__.py
@@ -1,0 +1,23 @@
+"""Data pipeline package initialization.
+
+Adds the package directory to ``sys.path`` so legacy imports like
+``import market_data`` continue to work.  Common submodules are exposed
+via ``__all__`` and imported lazily to avoid side effects during package
+import."""
+
+from importlib import import_module
+from pathlib import Path
+from typing import Any
+import sys
+
+_PACKAGE_DIR = Path(__file__).resolve().parent
+if str(_PACKAGE_DIR) not in sys.path:
+    sys.path.append(str(_PACKAGE_DIR))
+
+__all__ = ["streamlit_screener"]
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        return import_module(f"{__name__}.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- add __init__ to data_pipeline to make package importable
- lazily expose `streamlit_screener` and preserve legacy import paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e1a5cc7a4832896e6fa4bf884a166