### PR TITLE
refactor: import config once and expose threaded fetch

### DIFF
--- a/data_pipeline/market_data.py
+++ b/data_pipeline/market_data.py
@@ -9,7 +9,6 @@ implementation.
 """
 
 
-from . import config
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -41,6 +40,7 @@ __all__ = [
     "save_fundamentals_cache",
     "fetch_historical_data",
     "fetch_fundamental_data",
+    "fetch_fundamentals_threaded",
     "combine_price_and_fundamentals",
     "round_financial_columns",
 ]
@@ -70,4 +70,3 @@ def fetch_fundamentals_threaded(tickers: list[str], use_cache: bool = True) -> l
                 logging.error(f"Error fetching data for {ticker}: {exc}")
     return results
 
-__all__.insert(4, "fetch_fundamentals_threaded")


### PR DESCRIPTION
## Summary
- remove redundant top-level import of config in market_data
- add fetch_fundamentals_threaded directly to __all__

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e210c5ea48328a3f92772e31e4f2b