### PR TITLE
feat: make Gmail credential paths configurable

### DIFF
--- a/data_pipeline/README.md
+++ b/data_pipeline/README.md
@@ -30,7 +30,8 @@ pip install -r requirements.txt
 ### 3️⃣ Configure Your Environment
 - ✅ Set the `DATABASE_URL` for a hosted database (e.g., Supabase/PostgreSQL)
 - ✅ Set your cache expiry settings
-- ✅ Ensure your Gmail credentials are correct (optional for alerts)
+- ✅ Ensure your Gmail credentials are available (optional for alerts). Use
+  `GMAIL_CREDENTIALS_FILE` and `GMAIL_TOKEN_FILE` to override default paths.
 
 ### 4️⃣ Initialize Cache & Database (Optional)
 - Cache will create itself on first run
@@ -75,7 +76,8 @@ point to `streamlit_app.py` when deploying there.
   2. If not set, it tries `st.secrets["DATABASE_URL"]` (common on Streamlit Cloud).
   3. If still missing, it falls back to a **local SQLite database** (`data/stocks_data.db`) for development/testing.
 - **Hosted database** (e.g., Supabase/PostgreSQL) is strongly recommended for production to ensure persistence across runs.
-- Gmail alerts use credentials from `credentials.json` (optional).
+- Gmail alerts use credentials from `GMAIL_CREDENTIALS_FILE` (defaults to
+  `credentials.json`) and store the token in `GMAIL_TOKEN_FILE`.
 
 ---
 

--- a/data_pipeline/UK_data.py
+++ b/data_pipeline/UK_data.py
@@ -245,7 +245,11 @@ def main(tickers, start_date, end_date, use_cache=True):
         Dbhelper.close()
 
         # Prepare and send email notification
-        gmail_service = get_gmail_service()  # Initialize Gmail API service once
+        try:
+            gmail_service = get_gmail_service()  # Initialize Gmail API service once
+        except FileNotFoundError as e:
+            logger.error(e)
+            gmail_service = None
 
         if gmail_service is None:
             logger.error("Failed to initialize Gmail service. Email notification will not be sent.")

--- a/data_pipeline/config.py
+++ b/data_pipeline/config.py
@@ -67,6 +67,15 @@ if not DATABASE_URL:
 ENGINE = create_engine(DATABASE_URL)
 
 # ---------------------------------------------------------------------------
+# Gmail API configuration
+#
+# Paths to the OAuth client secrets and token files can be overridden via the
+# ``GMAIL_CREDENTIALS_FILE`` and ``GMAIL_TOKEN_FILE`` environment variables.
+# ---------------------------------------------------------------------------
+GMAIL_CREDENTIALS_FILE = os.environ.get("GMAIL_CREDENTIALS_FILE", "credentials.json")
+GMAIL_TOKEN_FILE = os.environ.get("GMAIL_TOKEN_FILE", "token.json")
+
+# ---------------------------------------------------------------------------
 # Cache backend configuration
 #
 # The cache system can be backed by different stores. Set

--- a/data_pipeline/gmail_utils.py
+++ b/data_pipeline/gmail_utils.py
@@ -6,27 +6,64 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 import logging
+from typing import Optional
+
+try:
+    from . import config
+except ImportError:  # pragma: no cover - fallback when running as script
+    import config  # type: ignore
 
 logger = logging.getLogger(__name__)
 
 # If modifying these SCOPES, delete token.json.
 SCOPES = ['https://www.googleapis.com/auth/gmail.send']
 
-def get_gmail_service():
+
+def get_gmail_service(
+    credentials_path: Optional[str] = None,
+    token_path: Optional[str] = None,
+):
+    """Return an authenticated Gmail API service instance.
+
+    Parameters
+    ----------
+    credentials_path:
+        Path to the OAuth2 client secrets JSON file. Defaults to
+        ``config.GMAIL_CREDENTIALS_FILE``.
+    token_path:
+        Path to the stored user token. Defaults to
+        ``config.GMAIL_TOKEN_FILE``.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the credentials file does not exist.
+    """
+
+    credentials_path = credentials_path or config.GMAIL_CREDENTIALS_FILE
+    token_path = token_path or config.GMAIL_TOKEN_FILE
+
+    if not os.path.exists(credentials_path):
+        raise FileNotFoundError(
+            f"Gmail credentials file not found at {credentials_path}. "
+            "Set the correct path via parameters or the GMAIL_CREDENTIALS_FILE environment variable."
+        )
+
     creds = None
     # token.json stores user's access and refresh tokens.
-    if os.path.exists('token.json'):
-        creds = Credentials.from_authorized_user_file('token.json', SCOPES)
+    if os.path.exists(token_path):
+        creds = Credentials.from_authorized_user_file(token_path, SCOPES)
     # If there are no valid credentials, log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
-                'credentials.json', SCOPES)
+                credentials_path, SCOPES
+            )
             creds = flow.run_local_server(port=0)
         # Save credentials for next run
-        with open('token.json', 'w') as token:
+        with open(token_path, 'w') as token:
             token.write(creds.to_json())
 
     service = build('gmail', 'v1', credentials=creds)


### PR DESCRIPTION
## Summary
- add config and optional parameters for Gmail credential and token file paths
- handle missing credentials.json with a friendly error
- document Gmail credential environment variables and add error handling to UK data pipeline

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e2119f8608328b34526cb11cc502e