### PR TITLE
Remove unused cache_dir parameter from cache helpers

### DIFF
--- a/data_pipeline/UK_data.py
+++ b/data_pipeline/UK_data.py
@@ -71,7 +71,6 @@ except ImportError:  # pragma: no cover - fallback for script execution
 
 def load_cached_fundamentals(
     ticker: str,
-    cache_dir: str = config.CACHE_DIR,
     expiry_minutes: int = config.CACHE_EXPIRY_MINUTES,
 ) -> Optional[dict]:
     try:
@@ -81,9 +80,7 @@ def load_cached_fundamentals(
         return None
 
 
-def save_fundamentals_cache(
-    ticker: str, data: dict, cache_dir: str = config.CACHE_DIR
-) -> None:
+def save_fundamentals_cache(ticker: str, data: dict) -> None:
     try:
         _save_fundamentals_cache(ticker, data)
     except Exception as e:  # pragma: no cover - best effort logging


### PR DESCRIPTION
## Summary
- Drop the unused `cache_dir` argument from `load_cached_fundamentals` and `save_fundamentals_cache`
- Keep caching behaviour intact while relying on `config.CACHE_DIR`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e210f71048328b87d77058819379b