### PR TITLE
Use async bulk fundamentals fetch

### DIFF
--- a/data_pipeline/test_data.py
+++ b/data_pipeline/test_data.py
@@ -33,9 +33,9 @@ class TestMarketData(unittest.TestCase):
         loaded = market_data.load_cached_fundamentals(ticker)
         self.assertEqual(loaded, test_data)
 
-    @patch('yfinance.Ticker')
-    def test_fetch_fundamental_data(self, mock_ticker):
-        # Setup mock object to simulate yfinance.Ticker().info
+    @patch('yfinance.Tickers')
+    def test_fetch_fundamental_data(self, mock_tickers):
+        # Setup mock object to simulate yfinance.Tickers().tickers[ticker].info
         ticker_name = "MOCK.L"
         mock_info = {
             'returnOnEquity': 0.12, 'grossMargins': 0.3, 'operatingMargins': 0.25,
@@ -44,12 +44,14 @@ class TestMarketData(unittest.TestCase):
             'currentRatio': 1.2, 'quickRatio': 1.0, 'dividendYield': 0.04,
             'marketCap': 1e9, 'beta': 1.1, 'averageVolume': 1000000
         }
-        mock_ticker.return_value.info = mock_info
+        mock_ticker_obj = unittest.mock.Mock()
+        mock_ticker_obj.info = mock_info
+        mock_tickers.return_value.tickers = {ticker_name: mock_ticker_obj}
 
-        result = market_data.fetch_fundamental_data(ticker_name, use_cache=False)
-        self.assertEqual(result['Ticker'], ticker_name)
-        self.assertAlmostEqual(result['returnOnEquity'], 0.12)
-        self.assertIn('marketCap', result)
+        result_list = market_data.fetch_fundamental_data([ticker_name], use_cache=False)
+        self.assertEqual(result_list[0]['Ticker'], ticker_name)
+        self.assertAlmostEqual(result_list[0]['returnOnEquity'], 0.12)
+        self.assertIn('marketCap', result_list[0])
 
     @patch('yfinance.download')
     def test_fetch_historical_data(self, mock_download):

--- a/data_pipeline/test_threaded_fetch.py
+++ b/data_pipeline/test_threaded_fetch.py
@@ -5,7 +5,7 @@ from data_pipeline import market_data
 class TestThreadedFetch(unittest.TestCase):
     @patch('data_pipeline.market_data.fetch_fundamental_data')
     def test_multi_ticker_threaded(self, mock_fetch):
-        mock_fetch.side_effect = [
+        mock_fetch.return_value = [
             {"Ticker": "A.L", "returnOnEquity": 0.1},
             {"Ticker": "B.L", "returnOnEquity": 0.2},
             {"Ticker": "C.L", "returnOnEquity": 0.3}
@@ -19,6 +19,7 @@ class TestThreadedFetch(unittest.TestCase):
         self.assertAlmostEqual(return_on_equity["A.L"], 0.1)
         self.assertAlmostEqual(return_on_equity["B.L"], 0.2)
         self.assertAlmostEqual(return_on_equity["C.L"], 0.3)
+        mock_fetch.assert_called_once_with(tickers, use_cache=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fetch fundamental data for many tickers at once using `yf.Tickers`
- add non-blocking retry logic with asyncio
- update wrappers and tests to use new bulk API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e27c1a7c88328b3779f46a58d7c52