### PR TITLE
docs: align database filename with configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ paste the contents of your local `secrets.toml`.
 
 The data pipeline reads the connection string using
 `st.secrets["DATABASE_URL"]`. If it is not provided a SQLite database named
-`stocks_data.db` will be created inside the pipeline's data directory.
+`app.db` will be created inside the pipeline's data directory.
 
 ### Running the Streamlit Screener
 

--- a/data_pipeline/README.md
+++ b/data_pipeline/README.md
@@ -74,7 +74,7 @@ point to `streamlit_app.py` when deploying there.
 - **Database configuration**:
   1. The app first checks the `DATABASE_URL` environment variable (recommended for production).
   2. If not set, it tries `st.secrets["DATABASE_URL"]` (common on Streamlit Cloud).
-  3. If still missing, it falls back to a **local SQLite database** (`data/stocks_data.db`) for development/testing.
+  3. If still missing, it falls back to a **local SQLite database** (`data/app.db`) for development/testing.
 - **Hosted database** (e.g., Supabase/PostgreSQL) is strongly recommended for production to ensure persistence across runs.
 - Gmail alerts use credentials from `GMAIL_CREDENTIALS_FILE` (defaults to
   `credentials.json`) and store the token in `GMAIL_TOKEN_FILE`.


### PR DESCRIPTION
## Summary
- update README references to use app.db, matching `data_pipeline/config.py`
- correct data_pipeline docs for fallback SQLite database path

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e270059b48328b40d3f3ca3b4b3c4