### PR TITLE
Optimize load_data query and add DB indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,11 @@ fetches the last decade of data by default; adjust `--years` as needed:
 python data_pipeline/UK_data.py --years 10
 ```
 
+### Optimized Data Loading
+
+The `load_data` function now retrieves only the necessary columns within the
+requested date range using a parameterized SQL query. Database indexes on the
+`Date` and `Ticker` columns are created automatically to speed up subsequent
+queries.
+
 


### PR DESCRIPTION
## Summary
- Select only needed columns and date range via parameterized SQL in `load_data`
- Create indexes on `Date` and `Ticker` for faster lookups
- Document optimized data loading strategy

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689e27c745248328b330c8b62ff3482e