### PR TITLE
Use SQLAlchemy text object for screener query

### DIFF
--- a/data_pipeline/streamlit_screener.py
+++ b/data_pipeline/streamlit_screener.py
@@ -88,12 +88,11 @@ def load_data(start_date: str, end_date: str) -> pd.DataFrame:
                 )
             )
 
-        query = (
+        query = text(
             "SELECT Date, Ticker, CompanyName, factor_composite, "
             "return_12m, earnings_yield, norm_quality_score, marketCap "
             "FROM financial_tbl "
-            "WHERE Date BETWEEN %(start)s AND %(end)s"
-
+            "WHERE Date BETWEEN :start AND :end"
         )
         df = pd.read_sql(query, engine, params={"start": start_date, "end": end_date})
     except SQLAlchemyError as exc:


### PR DESCRIPTION
## Summary
- use `sqlalchemy.text` with named parameters for screener SQL

## Testing
- `pytest`
- `python - <<'PY'` (SQLite query demonstration)
- `pip install pglite` *(fails: Could not find a version that satisfies the requirement pglite)*
- `apt-get update` *(fails: repository ... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689e3396f88883288fe5e28bb3bc0fd3