### PR TITLE
feat: warn when no screener data

### DIFF
--- a/data_pipeline/streamlit_screener.py
+++ b/data_pipeline/streamlit_screener.py
@@ -119,74 +119,73 @@ with st.spinner("Loading data..."):
     df = load_data(start_date, end_date)
 
 if df is None or df.empty:
-    st.stop()
-
-
-# Ensure we have the necessary columns
-required_columns = [
-    "Ticker",
-    "CompanyName",
-    "factor_composite",
-    "return_12m",
-    "earnings_yield",
-    "norm_quality_score",
-    "marketCap",
-]
-if not all(col in df.columns for col in required_columns):
-    st.error("Data is missing required columns. Please check your database.")
-
-# --- Filter and process data ---
-# 1. Filter by market cap
-filtered = df[df["marketCap"] >= min_mktcap]
-
-# 2. For each ticker, select the row with the latest date (or highest factor_composite)
-if "Date" in filtered.columns:
-    # Use latest date per ticker
-    filtered = filtered.sort_values("Date").groupby("Ticker", as_index=False).last()
+    st.warning("No data found. Adjust filters or initialize the database.")
 else:
-    # Use highest factor_composite per ticker
-    filtered = (
-        filtered.sort_values("factor_composite", ascending=False)
-        .groupby("Ticker", as_index=False)
-        .first()
+    # Ensure we have the necessary columns
+    required_columns = [
+        "Ticker",
+        "CompanyName",
+        "factor_composite",
+        "return_12m",
+        "earnings_yield",
+        "norm_quality_score",
+        "marketCap",
+    ]
+    if not all(col in df.columns for col in required_columns):
+        st.error("Data is missing required columns. Please check your database.")
+
+    # --- Filter and process data ---
+    # 1. Filter by market cap
+    filtered = df[df["marketCap"] >= min_mktcap]
+
+    # 2. For each ticker, select the row with the latest date (or highest factor_composite)
+    if "Date" in filtered.columns:
+        # Use latest date per ticker
+        filtered = filtered.sort_values("Date").groupby("Ticker", as_index=False).last()
+    else:
+        # Use highest factor_composite per ticker
+        filtered = (
+            filtered.sort_values("factor_composite", ascending=False)
+            .groupby("Ticker", as_index=False)
+            .first()
+        )
+
+    # 3. Sort by factor_composite
+    filtered = filtered.sort_values("factor_composite", ascending=False).reset_index(
+        drop=True
     )
 
-# 3. Sort by factor_composite
-filtered = filtered.sort_values("factor_composite", ascending=False).reset_index(
-    drop=True
-)
+    # 4. Ensure CompanyName exists — if not, fetch it separately or add placeholder
+    if "CompanyName" not in filtered.columns:
+        filtered["CompanyName"] = "Unknown Company"
 
-# 4. Ensure CompanyName exists — if not, fetch it separately or add placeholder
-if "CompanyName" not in filtered.columns:
-    filtered["CompanyName"] = "Unknown Company"
+    # 5. Add proper rank
+    filtered["rank"] = filtered.index + 1
 
-# 5. Add proper rank
-filtered["rank"] = filtered.index + 1
+    st.markdown(f"### Top {top_n} UK Stocks by Multi-Factor Composite Score")
+    cols_to_show = [
+        "Ticker",
+        "CompanyName",
+        "factor_composite",
+        "return_12m",
+        "earnings_yield",
+        "norm_quality_score",
+        "marketCap",
+        "rank",
+    ]
+    cols_to_show = [c for c in cols_to_show if c in filtered.columns]
+    st.dataframe(filtered.head(top_n)[cols_to_show])
 
-st.markdown(f"### Top {top_n} UK Stocks by Multi-Factor Composite Score")
-cols_to_show = [
-    "Ticker",
-    "CompanyName",
-    "factor_composite",
-    "return_12m",
-    "earnings_yield",
-    "norm_quality_score",
-    "marketCap",
-    "rank",
-]
-cols_to_show = [c for c in cols_to_show if c in filtered.columns]
-st.dataframe(filtered.head(top_n)[cols_to_show])
+    st.markdown("#### 📈 Factor Composite Score Bar Chart")
+    st.bar_chart(filtered.head(top_n).set_index("Ticker")["factor_composite"])
 
-st.markdown("#### 📈 Factor Composite Score Bar Chart")
-st.bar_chart(filtered.head(top_n).set_index("Ticker")["factor_composite"])
+    st.download_button(
+        label="Download as CSV",
+        data=filtered.head(top_n).to_csv(index=False),
+        file_name="screener_output.csv",
+        mime="text/csv",
+    )
 
-st.download_button(
-    label="Download as CSV",
-    data=filtered.head(top_n).to_csv(index=False),
-    file_name="screener_output.csv",
-    mime="text/csv",
-)
-
-st.info(
-    "Uses InvestWiseUK analytics engine pipeline. Replace with your real factor output for production if demoing."
-)
+    st.info(
+        "Uses InvestWiseUK analytics engine pipeline. Replace with your real factor output for production if demoing."
+    )


### PR DESCRIPTION
## Summary
- warn users when no screener data is available instead of stopping execution

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e3772de488328b3f449ea5ed023a6