### PR TITLE
Support incremental database updates with upsert

### DIFF
--- a/data_pipeline/UK_data.py
+++ b/data_pipeline/UK_data.py
@@ -259,8 +259,16 @@ def main(tickers, start_date, end_date, use_cache=True):
     if financial_df is not None:
         financial_tbl = "financial_tbl"
         Dbhelper = DBHelper(config.DATABASE_URL)  # Create a new DBHelper instance
-        Dbhelper.create_table(financial_tbl, financial_df) # Create table if not exists
-        Dbhelper.insert_dataframe(financial_tbl, financial_df) # Insert computed factors into the table
+        Dbhelper.create_table(
+            financial_tbl,
+            financial_df,
+            primary_keys=["Date", "Ticker"],
+        )  # Create table if not exists
+        Dbhelper.insert_dataframe(
+            financial_tbl,
+            financial_df,
+            unique_cols=["Date", "Ticker"],
+        )  # Upsert computed factors
         Dbhelper.close()
 
         # Prepare and send email notification

--- a/data_pipeline/db_utils.py
+++ b/data_pipeline/db_utils.py
@@ -1,8 +1,17 @@
-from typing import Optional
+from typing import Optional, Sequence
 
 import pandas as pd
-from sqlalchemy import (Column, Float, MetaData, Table, Text as SAText,
-                        create_engine, inspect, text)
+from sqlalchemy import (
+    Column,
+    Float,
+    MetaData,
+    Table,
+    Text as SAText,
+    create_engine,
+    inspect,
+    text,
+)
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from . import config
 
@@ -26,13 +35,19 @@ class DBHelper:
         """Safely quote an identifier (e.g., table/column name)."""
         return self.preparer.quote(identifier)
 
-    def create_table(self, table_name, df):
+    def create_table(
+        self,
+        table_name: str,
+        df: pd.DataFrame,
+        primary_keys: Optional[Sequence[str]] = None,
+    ) -> None:
         dtype_map = self.df_sql_dtypes(df)
         metadata = MetaData()
         columns = []
         for col, dtype in dtype_map.items():
             sql_type = Float if dtype == 'FLOAT' else SAText
-            columns.append(Column(col, sql_type))
+            is_pk = primary_keys and col in primary_keys
+            columns.append(Column(col, sql_type, primary_key=bool(is_pk)))
         table = Table(table_name, metadata, *columns)
         metadata.create_all(self.engine, tables=[table])
 
@@ -54,8 +69,31 @@ class DBHelper:
         with self.engine.begin() as conn:
             conn.execute(table.insert(), row_dict)
 
-    def insert_dataframe(self, table_name, df):
-        df.to_sql(table_name, self.engine, if_exists='replace', index=False)
+    def insert_dataframe(
+        self,
+        table_name: str,
+        df: pd.DataFrame,
+        unique_cols: Optional[Sequence[str]] = None,
+    ) -> None:
+        if df.empty:
+            return
+
+        if unique_cols:
+            metadata = MetaData()
+            table = Table(table_name, metadata, autoload_with=self.engine)
+            insert_stmt = sqlite_insert(table)
+            update_cols = {
+                c.name: insert_stmt.excluded[c.name]
+                for c in table.columns
+                if c.name not in unique_cols
+            }
+            upsert_stmt = insert_stmt.on_conflict_do_update(
+                index_elements=list(unique_cols), set_=update_cols
+            )
+            with self.engine.begin() as conn:
+                conn.execute(upsert_stmt, df.to_dict(orient="records"))
+        else:
+            df.to_sql(table_name, self.engine, if_exists="append", index=False)
 
     def close(self):
         self.engine.dispose()

--- a/data_pipeline/test_data.py
+++ b/data_pipeline/test_data.py
@@ -158,6 +158,16 @@ class TestDBHelper(unittest.TestCase):
         result = pd.read_sql("SELECT * FROM test_tbl", self.helper.engine)
         self.assertEqual(len(result), 2)
         self.assertIn("Close", result.columns)
+
+    def test_upsert_dataframe(self):
+        self.helper.create_table("test_tbl", self.df, primary_keys=["Ticker"])
+        self.helper.insert_dataframe("test_tbl", self.df, unique_cols=["Ticker"])
+        updated = self.df.copy()
+        updated.loc[0, "Close"] = 150
+        self.helper.insert_dataframe("test_tbl", updated, unique_cols=["Ticker"])
+        result = pd.read_sql("SELECT * FROM test_tbl", self.helper.engine)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[result["Ticker"] == "A.L"]["Close"].iloc[0], 150)
         
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- implement optional primary key support in DBHelper.create_table
- add upsert-based insert_dataframe to append/update instead of replacing
- update UK data pipeline to upsert on Date/Ticker and extend tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e3c886d008328a2d3057b35f2bf86