### PR TITLE
Set TTL on Streamlit cache to one hour

### DIFF
--- a/data_pipeline/streamlit_screener.py
+++ b/data_pipeline/streamlit_screener.py
@@ -32,8 +32,8 @@ today = datetime.today()
 end_date = today.strftime("%Y-%m-%d")
 start_date = (today - timedelta(days=years * 365)).strftime("%Y-%m-%d")
 
-
-@st.cache_data(show_spinner=False)
+# Cache data for one hour (TTL 3600s) to balance database load with freshness
+@st.cache_data(show_spinner=False, ttl=3600)
 def load_data(start_date: str, end_date: str) -> pd.DataFrame:
     """Load data from database, caching the result."""
 


### PR DESCRIPTION
## Summary
- add one-hour TTL to Streamlit cache to balance freshness and DB load

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e4bdf09c48328a2767bb7862cb359