### PR TITLE
Handle zero-volume data in Amihud calculation

### DIFF
--- a/data_pipeline/compute_factors.py
+++ b/data_pipeline/compute_factors.py
@@ -85,9 +85,13 @@ def compute_factors(df: pd.DataFrame) -> pd.DataFrame:
 
     # --- Size / Liquidity ---
     df['log_marketCap'] = np.log(df['marketCap'])
-    df['avg_volume_21d'] = df.groupby('Ticker')['Volume'].transform(lambda x: x.rolling(21).mean())    
+    df['avg_volume_21d'] = df.groupby('Ticker')['Volume'].transform(lambda x: x.rolling(21).mean())
+    # Replace zero volumes with NaN prior to Amihud calculation
+    adj_volume = df['Volume'].replace(0, np.nan)
     # Calculate raw Amihud
-    df['amihud_raw'] = (df['Close'].pct_change().abs() / (df['Volume'] * df['Close']))
+    df['amihud_raw'] = df['Close'].pct_change().abs() / (adj_volume * df['Close'])
+    # Replace infinite values with NaN
+    df['amihud_raw'] = df['amihud_raw'].replace([np.inf, -np.inf], np.nan)
     # 21-day rolling mean by ticker (final Amihud)
     df['amihud_illiquidity'] = df.groupby('Ticker')['amihud_raw'].transform(lambda x: x.rolling(21).mean())
     # Optionally: drop the intermediate column

--- a/data_pipeline/test_amihud.py
+++ b/data_pipeline/test_amihud.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pandas as pd
+
+from data_pipeline.compute_factors import compute_factors
+
+
+def test_zero_volume_results_in_nan_amihud():
+    dates = pd.date_range('2023-01-01', periods=25, freq='D')
+    df = pd.DataFrame({
+        'Date': dates.astype(str),
+        'Ticker': ['TEST.L'] * 25,
+        'Close': np.linspace(100, 124, 25),
+        'Volume': [100] * 24 + [0],
+        'returnOnEquity': [0.1] * 25,
+        'profitMargins': [0.1] * 25,
+        'priceToBook': [1.0] * 25,
+        'trailingPE': [10.0] * 25,
+        'marketCap': [1e6] * 25,
+    })
+
+    factors = compute_factors(df.copy())
+    # Last row has zero volume -> NaN
+    assert np.isnan(factors.iloc[-1]['amihud_illiquidity'])
+    # Previous row has non-zero volume and enough history -> finite
+    assert np.isfinite(factors.iloc[-2]['amihud_illiquidity'])


### PR DESCRIPTION
## Summary
- Avoid divide-by-zero when computing Amihud by treating zero volumes as NaN
- Clean up infinite results from Amihud calculation
- Test that zero-volume entries produce NaN Amihud values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e4be2fed4832894c06b0835d0e567