### PR TITLE
Document optional cache backends and guard imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,16 @@ MAX_THREADS=20 python data_pipeline/UK_data.py --years 10
 ```
 
 
+### Optional cache backends
+
+The pipeline defaults to a local filesystem cache. To use Redis or Amazon S3
+as the cache backend, install the corresponding optional packages:
+
+```bash
+pip install redis   # required for CACHE_BACKEND=redis
+pip install boto3   # required for CACHE_BACKEND=s3
+```
+
+These dependencies are not installed by default, so ensure they are available
+before selecting the related backend.
+

--- a/data_pipeline/README.md
+++ b/data_pipeline/README.md
@@ -71,6 +71,12 @@ point to `streamlit_app.py` when deploying there.
   - `CACHE_REDIS_URL` – Redis connection string when using the Redis backend
   - `CACHE_S3_BUCKET` / `CACHE_S3_PREFIX` – S3 bucket (and optional key prefix)
   - **In-memory fundamentals cache** keeps entries for the session and only writes modified tickers back to the chosen backend (`cache_utils.py`)
+- Optional packages for remote backends:
+
+  ```bash
+  pip install redis   # required for CACHE_BACKEND=redis
+  pip install boto3   # required for CACHE_BACKEND=s3
+  ```
 - **Database configuration**:
   1. The app first checks the `DATABASE_URL` environment variable (recommended for production).
   2. If not set, it tries `st.secrets["DATABASE_URL"]` (common on Streamlit Cloud).

--- a/data_pipeline/cache_utils.py
+++ b/data_pipeline/cache_utils.py
@@ -29,12 +29,24 @@ _CACHE: Dict[str, Dict] = {}
 # Backend clients
 # ---------------------------------------------------------------------------
 if config.CACHE_BACKEND == "redis":
-    import redis  # type: ignore
+    try:
+        import redis  # type: ignore
+    except ImportError as exc:
+        raise ImportError(
+            "Redis backend selected but the 'redis' package is not installed. "
+            "Install it with 'pip install redis'."
+        ) from exc
 
     _client = redis.Redis.from_url(config.CACHE_REDIS_URL)
     _key = "fundamentals_cache"  # Redis hash name
 elif config.CACHE_BACKEND == "s3":
-    import boto3  # type: ignore
+    try:
+        import boto3  # type: ignore
+    except ImportError as exc:
+        raise ImportError(
+            "S3 backend selected but the 'boto3' package is not installed. "
+            "Install it with 'pip install boto3'."
+        ) from exc
 
     _client = boto3.client("s3")
     _prefix = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,3 +88,7 @@ websockets==15.0.1
 wsproto==1.2.0
 yfinance==0.2.63
 zope.interface==7.2
+
+# Optional extras for cache backends
+# redis  # for CACHE_BACKEND=redis
+# boto3  # for CACHE_BACKEND=s3


### PR DESCRIPTION
## Summary
- note optional Redis and S3 cache backends and how to install their packages
- add import guards so selecting redis or s3 backends errors clearly when packages are missing
- document optional extras in requirements

## Testing
- `python -m py_compile data_pipeline/cache_utils.py`
- `CACHE_BACKEND=redis python - <<'PY'
import data_pipeline.cache_utils
PY`
- `CACHE_BACKEND=s3 python - <<'PY'
import data_pipeline.cache_utils
PY`


------
https://chatgpt.com/codex/tasks/task_b_689e4bef54f48328a67c71c3ffc99070