### PR TITLE
Use logging instead of print

### DIFF
--- a/data_pipeline/Macro_data.py
+++ b/data_pipeline/Macro_data.py
@@ -1,3 +1,4 @@
+import logging
 import quandl
 import pandas as pd
 import streamlit as st
@@ -6,6 +7,9 @@ try:
     DEFAULT_API_KEY = st.secrets["QUANDL_API_KEY"]
 except Exception:
     DEFAULT_API_KEY = None
+
+
+logger = logging.getLogger(__name__)
 
 class FiveYearMacroDataLoader:
     def __init__(self, api_key: str | None = None,
@@ -26,7 +30,7 @@ class FiveYearMacroDataLoader:
             data.rename(columns={"Value": "GDP_Growth_YoY"}, inplace=True)
             return data
         except Exception as e:
-            print(f"Error fetching GDP Growth Data: {str(e)}")
+            logger.error("Error fetching GDP Growth Data: %s", e)
             return None
 
     def fetch_inflation_rate(self):
@@ -55,9 +59,9 @@ if __name__ == "__main__":
 
     macro_data = loader.get_combined_macro_data()
     if macro_data is not None:
-        print("✅ Combined 5-Year UK Macro Data:")
-        print(macro_data)
+        logger.info("✅ Combined 5-Year UK Macro Data:")
+        logger.info("\n%s", macro_data)
         # Optionally save to CSV
         macro_data.to_csv("UK_5Year_Macro_Data.csv", index=False)
     else:
-        print("❌ Failed to fetch macro data.")
+        logger.error("❌ Failed to fetch macro data.")

--- a/data_pipeline/trial.py
+++ b/data_pipeline/trial.py
@@ -1,4 +1,7 @@
+import logging
 import quandl
+
+logger = logging.getLogger(__name__)
 quandl.ApiConfig.api_key = "pXBknNEt9LEV6DRBnfhs"
 data = quandl.get("FRED/CPILFESL")  # US CPI (free dataset)
-print(data.tail())
+logger.info("\n%s", data.tail())

--- a/data_pipeline/update_financial_data.py
+++ b/data_pipeline/update_financial_data.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 from datetime import datetime, timedelta
+import logging
 
 import pandas as pd
 from sqlalchemy import create_engine, inspect
@@ -20,6 +21,9 @@ try:  # Prefer package-relative imports
 except ImportError:  # pragma: no cover - fallback when run as script
     import config  # type: ignore
     import UK_data  # type: ignore
+
+
+logger = logging.getLogger(__name__)
 
 
 def _needs_fetch(engine, start_date: str, end_date: str) -> bool:
@@ -53,7 +57,7 @@ def main(start_date: str, end_date: str) -> None:
         if _needs_fetch(engine, start_date, end_date):
             UK_data.main(config.FTSE_100_TICKERS, start_date, end_date)
         else:
-            print("financial_tbl already contains requested data; skipping fetch.")
+            logger.info("financial_tbl already contains requested data; skipping fetch.")
     finally:
         engine.dispose()
 


### PR DESCRIPTION
## Summary
- add module-level loggers to data pipeline scripts
- replace print calls with logger.info/error, capturing DataFrame info where needed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e4bf0ebec8328abe86f9f27ad11b4