### PR TITLE
Make Streamlit optional with env var fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ cp .streamlit/secrets.example.toml .streamlit/secrets.toml
 
 Edit `.streamlit/secrets.toml` and fill in your own values. At a minimum set
 `DATABASE_URL` (e.g. `postgresql://user:password@host:5432/database`) and any
-required API keys like `QUANDL_API_KEY`.
+required API keys like `QUANDL_API_KEY`. These values can also be supplied via
+environment variables when Streamlit's secrets are not available.
 
 When deploying to Streamlit Cloud, open the app's **⚙️ Settings → Secrets** and
 paste the contents of your local `secrets.toml`.
 
-The data pipeline reads the connection string using
-`st.secrets["DATABASE_URL"]`. If it is not provided a SQLite database named
+The data pipeline first checks the `DATABASE_URL` environment variable and then
+`st.secrets["DATABASE_URL"]`. If neither is provided a SQLite database named
 `app.db` will be created inside the pipeline's data directory.
 
 ### Running the Streamlit Screener

--- a/data_pipeline/Macro_data.py
+++ b/data_pipeline/Macro_data.py
@@ -1,11 +1,18 @@
+import os
 import quandl
 import pandas as pd
-import streamlit as st
 
 try:
-    DEFAULT_API_KEY = st.secrets["QUANDL_API_KEY"]
-except Exception:
-    DEFAULT_API_KEY = None
+    import streamlit as st
+except ImportError:  # pragma: no cover - optional dependency
+    st = None  # type: ignore
+
+DEFAULT_API_KEY = os.environ.get("QUANDL_API_KEY")
+if DEFAULT_API_KEY is None and st is not None:
+    try:
+        DEFAULT_API_KEY = st.secrets["QUANDL_API_KEY"]  # type: ignore[index]
+    except Exception:
+        pass
 
 class FiveYearMacroDataLoader:
     def __init__(self, api_key: str | None = None,


### PR DESCRIPTION
## Summary
- Handle optional Streamlit dependency with ImportError-aware imports.
- Pull configuration from environment variables when Streamlit secrets are unavailable.
- Document environment variable fallback for database and API keys.

## Testing
- `python -m py_compile data_pipeline/config.py data_pipeline/Macro_data.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e4bf27614832884afd3a7696f8df9