### PR TITLE
refactor: remove hardcoded Quandl key

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ cp .streamlit/secrets.example.toml .streamlit/secrets.toml
 
 Edit `.streamlit/secrets.toml` and fill in your own values. At a minimum set
 `DATABASE_URL` (e.g. `postgresql://user:password@host:5432/database`) and any
-required API keys like `QUANDL_API_KEY`.
+required API keys like `QUANDL_API_KEY`. The `QUANDL_API_KEY` can also be
+provided via the environment if you prefer not to use Streamlit secrets.
 
 When deploying to Streamlit Cloud, open the app's **⚙️ Settings → Secrets** and
 paste the contents of your local `secrets.toml`.
@@ -61,6 +62,16 @@ setting the `MAX_THREADS` environment variable:
 
 ```bash
 MAX_THREADS=20 python data_pipeline/UK_data.py --years 10
+```
+
+
+### Examples
+
+Sample scripts demonstrating API usage live in the `examples/` directory. For
+instance, after setting the `QUANDL_API_KEY` environment variable you can run:
+
+```bash
+python examples/quandl_example.py
 ```
 
 

--- a/data_pipeline/Macro_data.py
+++ b/data_pipeline/Macro_data.py
@@ -1,11 +1,14 @@
+import os
 import quandl
 import pandas as pd
 import streamlit as st
 
-try:
-    DEFAULT_API_KEY = st.secrets["QUANDL_API_KEY"]
-except Exception:
-    DEFAULT_API_KEY = None
+DEFAULT_API_KEY = os.environ.get("QUANDL_API_KEY")
+if DEFAULT_API_KEY is None:
+    try:
+        DEFAULT_API_KEY = st.secrets["QUANDL_API_KEY"]
+    except Exception:
+        DEFAULT_API_KEY = None
 
 class FiveYearMacroDataLoader:
     def __init__(self, api_key: str | None = None,

--- a/data_pipeline/trial.py
+++ b/data_pipeline/trial.py
@@ -1,4 +1,0 @@
-import quandl
-quandl.ApiConfig.api_key = "pXBknNEt9LEV6DRBnfhs"
-data = quandl.get("FRED/CPILFESL")  # US CPI (free dataset)
-print(data.tail())

--- a/examples/quandl_example.py
+++ b/examples/quandl_example.py
@@ -1,0 +1,16 @@
+"""Minimal Quandl API usage example."""
+import os
+import quandl
+
+
+def main() -> None:
+    api_key = os.environ.get("QUANDL_API_KEY")
+    if not api_key:
+        raise RuntimeError("Set the QUANDL_API_KEY environment variable")
+    quandl.ApiConfig.api_key = api_key
+    data = quandl.get("FRED/CPILFESL")  # US CPI (free dataset)
+    print(data.tail())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- remove trial script containing hardcoded Quandl API key
- load Quandl API key from environment variables with Streamlit secret fallback
- document env var usage and add sanitized Quandl example

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e4bf870a08328b0d0e51f0e5e2a8d