### PR TITLE
Add AWS credentials and env checks to data update workflow

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -18,9 +18,30 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Verify environment variables
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          QUANDL_API_KEY: ${{ secrets.QUANDL_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: |
+          missing=()
+          for var in DATABASE_URL QUANDL_API_KEY AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION; do
+            if [ -z "${!var}" ]; then
+              missing+=("$var")
+            fi
+          done
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "Missing required environment variables: ${missing[*]}"
+            exit 1
+          fi
       - name: Run data refresh
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           QUANDL_API_KEY: ${{ secrets.QUANDL_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         run: |
           python data_pipeline/UK_data.py --years 10


### PR DESCRIPTION
## Summary
- add step to verify required environment variables before running data refresh
- pass AWS credentials to data refresh workflow

## Testing
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*
- `yamllint .github/workflows/update-data.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e5d5e6c6c8328b8371fc42bbd4e1c