### PR TITLE
docs: add AWS configuration for S3 cache and RDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,27 @@ pip install boto3   # required for CACHE_BACKEND=s3
 ```
 
 These dependencies are not installed by default, so ensure they are available
-before selecting the related backend.
+before selecting the related backend. When using `CACHE_BACKEND=s3`, set the
+AWS credentials described in [AWS Configuration](#aws-configuration).
+
+### AWS Configuration
+
+Configure the following variables when connecting to AWS services such as RDS
+or the S3 cache backend:
+
+- `AWS_ACCESS_KEY_ID` – access key for an IAM user with S3 permissions.
+- `AWS_SECRET_ACCESS_KEY` – secret key associated with the IAM user.
+- `AWS_DEFAULT_REGION` – AWS region for your resources.
+- `CACHE_S3_BUCKET` – bucket name used when `CACHE_BACKEND=s3`.
+- `CACHE_S3_PREFIX` – optional key prefix within the bucket.
+
+If your database runs on AWS RDS, set `DATABASE_URL` accordingly. Example:
+
+```bash
+DATABASE_URL=postgresql://user:pass@mydb.xxxxx.us-east-1.rds.amazonaws.com:5432/dbname
+```
+
+These variables are only needed when using AWS resources—particularly the S3
+cache backend described in [Optional cache backends](#optional-cache-backends).
+For local caching and databases, they can be omitted.
 

--- a/data_pipeline/README.md
+++ b/data_pipeline/README.md
@@ -69,7 +69,8 @@ point to `streamlit_app.py` when deploying there.
 - **Cache backend** configurable via environment variables:
   - `CACHE_BACKEND` – `local` (default), `redis`, or `s3`
   - `CACHE_REDIS_URL` – Redis connection string when using the Redis backend
-  - `CACHE_S3_BUCKET` / `CACHE_S3_PREFIX` – S3 bucket (and optional key prefix)
+  - `CACHE_S3_BUCKET` / `CACHE_S3_PREFIX` – S3 bucket (and optional key prefix).
+    Requires the AWS credentials detailed in [AWS Configuration](#aws-configuration)
   - **In-memory fundamentals cache** keeps entries for the session and only writes modified tickers back to the chosen backend (`cache_utils.py`)
 - Optional packages for remote backends:
 
@@ -81,9 +82,27 @@ point to `streamlit_app.py` when deploying there.
   1. The app first checks the `DATABASE_URL` environment variable (recommended for production).
   2. If not set, it tries `st.secrets["DATABASE_URL"]` (common on Streamlit Cloud).
   3. If still missing, it falls back to a **local SQLite database** (`data/app.db`) for development/testing.
-- **Hosted database** (e.g., Supabase/PostgreSQL) is strongly recommended for production to ensure persistence across runs.
-- Gmail alerts use credentials from `GMAIL_CREDENTIALS_FILE` (defaults to
-  `credentials.json`) and store the token in `GMAIL_TOKEN_FILE`.
+  - **Hosted database** (e.g., Supabase/PostgreSQL) is strongly recommended for production to ensure persistence across runs.
+  - Gmail alerts use credentials from `GMAIL_CREDENTIALS_FILE` (defaults to
+    `credentials.json`) and store the token in `GMAIL_TOKEN_FILE`.
+
+## AWS Configuration
+
+Set these variables when connecting to AWS services such as RDS or the S3 cache backend:
+
+- `AWS_ACCESS_KEY_ID` – access key for an IAM user with S3 permissions.
+- `AWS_SECRET_ACCESS_KEY` – secret key associated with the IAM user.
+- `AWS_DEFAULT_REGION` – AWS region where your resources reside.
+- `CACHE_S3_BUCKET` – bucket name used when `CACHE_BACKEND=s3`.
+- `CACHE_S3_PREFIX` – optional key prefix within the bucket.
+
+To connect to a PostgreSQL database on AWS RDS, export `DATABASE_URL` as follows:
+
+```bash
+DATABASE_URL=postgresql://user:pass@mydb.xxxxx.eu-west-1.rds.amazonaws.com:5432/dbname
+```
+
+These variables are only necessary when using AWS resources, particularly the S3 cache backend discussed in [Notes on Cache & Data Persistence](#-notes-on-cache--data-persistence).
 
 ---
 


### PR DESCRIPTION
## Summary
- document AWS credentials and S3 cache settings in both READMEs
- add example `DATABASE_URL` for connecting to AWS RDS
- cross-link cache backend section so readers know when S3 credentials are required

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e5e31d0e08328abcd870002adf2b6