### PR TITLE
Raise error when Quandl API key missing

### DIFF
--- a/data_pipeline/Macro_data.py
+++ b/data_pipeline/Macro_data.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 import quandl
 import pandas as pd
@@ -23,6 +24,11 @@ class FiveYearMacroDataLoader:
                  start_date: str = "2020-01-01",
                  end_date: str = "2025-01-01"):
         self.api_key = api_key or DEFAULT_API_KEY
+        if self.api_key is None:
+            raise ValueError(
+                "No Quandl API key provided. Configure the QUANDL_API_KEY "
+                "environment variable or pass api_key to FiveYearMacroDataLoader."
+            )
         quandl.ApiConfig.api_key = self.api_key
         self.start_date = start_date
         self.end_date = end_date

--- a/data_pipeline/test_macro_loader.py
+++ b/data_pipeline/test_macro_loader.py
@@ -1,0 +1,13 @@
+import importlib
+import sys
+
+import pytest
+
+
+def test_loader_requires_api_key(monkeypatch):
+    """FiveYearMacroDataLoader should fail fast without an API key."""
+    monkeypatch.delenv("QUANDL_API_KEY", raising=False)
+    sys.modules.pop("data_pipeline.Macro_data", None)
+    macro_data = importlib.import_module("data_pipeline.Macro_data")
+    with pytest.raises(ValueError, match="QUANDL_API_KEY"):
+        macro_data.FiveYearMacroDataLoader()


### PR DESCRIPTION
## Summary
- ensure FiveYearMacroDataLoader raises a helpful error when no Quandl API key is configured
- add test verifying initialization fails without QUANDL_API_KEY

## Testing
- `pytest data_pipeline/test_macro_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689e5e3593008328a75df0737c4a6be1