### PR TITLE
Add missing logging import for macro data module

### DIFF
--- a/data_pipeline/Macro_data.py
+++ b/data_pipeline/Macro_data.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import quandl


### PR DESCRIPTION
## Summary
- add missing `import logging` to `Macro_data.py`
- verify logger usage imports across modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e5f6a67148328a45fa45389b78842