### PR TITLE
Enforce QUANDL API key requirement in macro data loader

### DIFF
--- a/data_pipeline/Macro_data.py
+++ b/data_pipeline/Macro_data.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 import quandl
 import pandas as pd
@@ -23,6 +24,10 @@ class FiveYearMacroDataLoader:
                  start_date: str = "2020-01-01",
                  end_date: str = "2025-01-01"):
         self.api_key = api_key or DEFAULT_API_KEY
+        if self.api_key is None:
+            raise ValueError(
+                "QUANDL_API_KEY is not configured. Set the env var or pass api_key."
+            )
         quandl.ApiConfig.api_key = self.api_key
         self.start_date = start_date
         self.end_date = end_date

--- a/tests/test_macro_data_loader.py
+++ b/tests/test_macro_data_loader.py
@@ -1,0 +1,13 @@
+import importlib
+
+import pytest
+
+
+def test_loader_requires_api_key(monkeypatch):
+    monkeypatch.delenv("QUANDL_API_KEY", raising=False)
+    module = importlib.reload(importlib.import_module("data_pipeline.Macro_data"))
+    with pytest.raises(
+        ValueError, match="QUANDL_API_KEY is not configured"
+    ):
+        module.FiveYearMacroDataLoader()
+


### PR DESCRIPTION
## Summary
- validate QUANDL API key during `FiveYearMacroDataLoader` initialization and raise a clear error when missing
- add regression test ensuring missing key triggers `ValueError`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e5f6cef88832883c3a93acbfaf1a6