### PR TITLE
Document required credentials in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,30 @@ The data pipeline first checks the `DATABASE_URL` environment variable and then
 `st.secrets["DATABASE_URL"]`. If neither is provided a SQLite database named
 `app.db` will be created inside the pipeline's data directory.
 
+### Required credentials
+
+The project expects several environment variables for external services. They
+can be supplied via a local `.env` file or added to `.streamlit/secrets.toml`.
+
+```env
+QUANDL_API_KEY=your_quandl_key
+DATABASE_URL=postgresql://user:password@host:5432/database
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+AWS_DEFAULT_REGION=us-west-2
+CACHE_S3_BUCKET=your-bucket
+CACHE_S3_PREFIX=cache/prefix
+```
+
+- `QUANDL_API_KEY` – used by `data_pipeline/Macro_data.py` for macroeconomic
+  data downloads.
+- `DATABASE_URL` – consumed throughout the pipeline and Streamlit app for
+  database connections.
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_DEFAULT_REGION` –
+  authenticate to Amazon S3 when using the S3 cache backend.
+- `CACHE_S3_BUCKET` and `CACHE_S3_PREFIX` – define the S3 location for cached
+  fundamentals in `data_pipeline/cache_utils.py`.
+
 ### Running the Streamlit Screener
 
 An interactive stock screener is available via Streamlit. Run it from the

--- a/data_pipeline/README.md
+++ b/data_pipeline/README.md
@@ -33,6 +33,27 @@ pip install -r requirements.txt
 - ✅ Ensure your Gmail credentials are available (optional for alerts). Use
   `GMAIL_CREDENTIALS_FILE` and `GMAIL_TOKEN_FILE` to override default paths.
 
+#### Required credentials
+
+Set the following variables in a `.env` file or in `.streamlit/secrets.toml`:
+
+```env
+QUANDL_API_KEY=your_quandl_key
+DATABASE_URL=postgresql://user:password@host:5432/database
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+AWS_DEFAULT_REGION=us-west-2
+CACHE_S3_BUCKET=your-bucket
+CACHE_S3_PREFIX=cache/prefix
+```
+
+- `QUANDL_API_KEY` – used by `Macro_data.py` to pull macroeconomic data.
+- `DATABASE_URL` – consumed by `config.py` and all database helpers.
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_DEFAULT_REGION` –
+  authenticate to S3 when `CACHE_BACKEND=s3`.
+- `CACHE_S3_BUCKET` and `CACHE_S3_PREFIX` – identify the S3 location for cached
+  fundamentals in `cache_utils.py`.
+
 ### 4️⃣ Initialize Cache & Database (Optional)
 - Cache will create itself on first run
 - Ensure your hosted database is reachable by the `DATABASE_URL`


### PR DESCRIPTION
## Summary
- detail QUANDL_API_KEY, DATABASE_URL and AWS cache variables in top-level README with sample `.env`
- add matching credentials section to `data_pipeline/README.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e5f6e3c748328bffe646128d853f1