### PR TITLE
Remove blank line before load_data

### DIFF
--- a/data_pipeline/streamlit_screener.py
+++ b/data_pipeline/streamlit_screener.py
@@ -35,7 +35,6 @@ start_date = (today - timedelta(days=years * 365)).strftime("%Y-%m-%d")
 
 # Cache data for one hour (TTL 3600s) to balance database load with freshness
 @st.cache_data(show_spinner=False, ttl=3600)
-
 def load_data(start_date: str, end_date: str) -> pd.DataFrame:
     """Load data from database, caching the result."""
 


### PR DESCRIPTION
## Summary
- fix decorator placement in streamlit screener by removing stray blank line

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689e7067ece08328833824653f4b94fa