### PR TITLE
Integrate macroeconomic data into pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 > 📝 **Note:**
 > This is a **pre-release** version. The project is under active development.
-> Phase 2 (Macro Data Integration) is planned in upcoming releases.
+> Macroeconomic data is integrated into the pipeline and stored alongside market
+> data.
 
 ### Required credentials
 
@@ -25,8 +26,8 @@ CACHE_S3_BUCKET=your-bucket
 CACHE_S3_PREFIX=cache/prefix
 ```
 
-- `QUANDL_API_KEY` – used by `data_pipeline/Macro_data.py` for macroeconomic
-  data downloads.
+- `QUANDL_API_KEY` – used by `data_pipeline/Macro_data.py` and consumed by
+  `data_pipeline/UK_data.py` to persist macroeconomic indicators.
 - `DATABASE_URL` – consumed throughout the pipeline for database connections.
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_DEFAULT_REGION` –
   authenticate to Amazon S3 when using the S3 cache backend.

--- a/data_pipeline/README.md
+++ b/data_pipeline/README.md
@@ -5,6 +5,7 @@
 
 **EquityAlphaEngine** is a UK Equity Analytics Platform that:
 - Fetches financial fundamentals and historical data
+- Ingests UK macroeconomic indicators (GDP growth and inflation)
 - Computes multi-factor scoring models
 - Caches data locally with expiry control
 - Outputs data that can be visualized in tools like Tableau or PowerBI
@@ -108,6 +109,8 @@ This will fetch data, compute factors, and update the database.
 ```
 python UK_data.py --start_date 2020-01-01 --end_date 2025-07-17
 ```
+The pipeline also pulls UK GDP growth and inflation figures and stores them in
+the `macro_data_tbl` table.
 
 ## ✅ Notes on Cache & Data Persistence
 

--- a/data_pipeline/test_macro_integration.py
+++ b/data_pipeline/test_macro_integration.py
@@ -1,0 +1,68 @@
+import pandas as pd
+
+from data_pipeline import UK_data
+
+
+def test_main_stores_macro_data(monkeypatch):
+    calls = []
+
+    class DummyDB:
+        def __init__(self, url):
+            pass
+
+        def create_table(self, name, df, primary_keys):
+            calls.append(("create", name, list(df.columns), primary_keys))
+
+        def insert_dataframe(self, name, df, unique_cols):
+            calls.append(("insert", name, len(df), unique_cols))
+
+        def close(self):
+            calls.append(("close",))
+
+    monkeypatch.setattr(UK_data, "DBHelper", DummyDB)
+    monkeypatch.setattr(
+        UK_data,
+        "fetch_historical_data",
+        lambda tickers, start, end: pd.DataFrame(
+            {
+                "Date": [pd.Timestamp("2020-01-01")],
+                "Open": [1],
+                "High": [1],
+                "Low": [1],
+                "Close": [1],
+                "Adj Close": [1],
+                "Volume": [1],
+                "Ticker": ["A"],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        UK_data,
+        "fetch_fundamental_data",
+        lambda tickers, use_cache=True: [{"Ticker": "A"}],
+    )
+    monkeypatch.setattr(
+        UK_data,
+        "compute_factors",
+        lambda df: pd.DataFrame({"Date": [pd.Timestamp("2020-01-01")], "Ticker": ["A"]}),
+    )
+    monkeypatch.setattr(UK_data, "round_financial_columns", lambda df: df)
+    monkeypatch.setattr(
+        UK_data,
+        "fetch_macro_data",
+        lambda start, end: pd.DataFrame(
+            {
+                "Date": [pd.Timestamp("2020-01-01")],
+                "GDP_Growth_YoY": [1.0],
+                "Inflation_YoY": [2.0],
+            }
+        ),
+    )
+    monkeypatch.setattr(UK_data, "get_gmail_service", lambda: object())
+    monkeypatch.setattr(UK_data, "create_message", lambda *args, **kwargs: None)
+    monkeypatch.setattr(UK_data, "send_message", lambda *args, **kwargs: None)
+
+    UK_data.main(["A"], "2020-01-01", "2020-12-31")
+
+    created_tables = [c[1] for c in calls if c[0] == "create"]
+    assert "macro_data_tbl" in created_tables


### PR DESCRIPTION
## Summary
- Import and use `FiveYearMacroDataLoader` in the UK data pipeline
- Save GDP and inflation data to `macro_data_tbl`
- Document macro data consumption and add regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68ac9d561504832899ca6987eaf563b2