### PR TITLE
Expose core data_pipeline submodules

### DIFF
--- a/data_pipeline/__init__.py
+++ b/data_pipeline/__init__.py
@@ -14,7 +14,14 @@ _PACKAGE_DIR = Path(__file__).resolve().parent
 if str(_PACKAGE_DIR) not in sys.path:
     sys.path.append(str(_PACKAGE_DIR))
 
-__all__: list[str] = []
+# Commonly used submodules are defined here for convenient access while
+# still allowing lazy importing via ``__getattr__``.
+__all__: list[str] = [
+    "market_data",
+    "compute_factors",
+    "db_utils",
+    "config",
+]
 
 
 def __getattr__(name: str) -> Any:


### PR DESCRIPTION
## Summary
- expose market_data, compute_factors, db_utils, and config modules via `data_pipeline.__all__`
- document lazy import mechanism for these submodules

## Testing
- `python - <<'PY' ...` (import check)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ac9d53ae448328b2f7b247ac57dadb