### PR TITLE
chore: remove trial script with hard-coded API key

### DIFF
--- a/data_pipeline/trial.py
+++ b/data_pipeline/trial.py
@@ -1,7 +1,0 @@
-import logging
-import quandl
-
-logger = logging.getLogger(__name__)
-quandl.ApiConfig.api_key = "pXBknNEt9LEV6DRBnfhs"
-data = quandl.get("FRED/CPILFESL")  # US CPI (free dataset)
-logger.info("\n%s", data.tail())


### PR DESCRIPTION
## Summary
- remove unused `trial.py` that contained a hard-coded Quandl API key

## Testing
- `QUANDL_API_KEY=dummy pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ac9d504b2483289aed7f54ccd169ee