### PR TITLE
refactor: centralize fundamentals wrapper

### DIFF
--- a/data_pipeline/UK_data.py
+++ b/data_pipeline/UK_data.py
@@ -238,17 +238,6 @@ def fetch_fundamental_data(
     else:
         return asyncio.create_task(_fetch_all())
 
-def fetch_fundamentals_threaded(
-    tickers: list[str], use_cache: bool = True
-) -> list[dict]:
-    """Backward compatible wrapper for ``fetch_fundamental_data``.
-
-    Historically, fundamentals were fetched in separate threads per ticker. The
-    new implementation already performs concurrent requests, so this wrapper
-    simply delegates to :func:`fetch_fundamental_data`.
-    """
-    return fetch_fundamental_data(tickers, use_cache=use_cache)
-
 def combine_price_and_fundamentals(price_df: pd.DataFrame, fundamentals_list: list[dict]) -> pd.DataFrame:
     """
     Merges price data DataFrame with a list of fundamental dicts (as DataFrame).

--- a/data_pipeline/test_threaded_fetch.py
+++ b/data_pipeline/test_threaded_fetch.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch
-from data_pipeline import market_data
+from data_pipeline.market_data import fetch_fundamentals_threaded
 
 class TestThreadedFetch(unittest.TestCase):
     @patch('data_pipeline.market_data.fetch_fundamental_data')
@@ -11,7 +11,7 @@ class TestThreadedFetch(unittest.TestCase):
             {"Ticker": "C.L", "returnOnEquity": 0.3}
         ]
         tickers = ["A.L", "B.L", "C.L"]
-        out = market_data.fetch_fundamentals_threaded(tickers, use_cache=False)
+        out = fetch_fundamentals_threaded(tickers, use_cache=False)
         self.assertEqual(len(out), 3)
         tickers_seen = set([d['Ticker'] for d in out])
         self.assertEqual(tickers_seen, set(["A.L", "B.L", "C.L"]))


### PR DESCRIPTION
## Summary
- remove redundant fetch_fundamentals_threaded from `UK_data`
- import fundamentals wrapper exclusively from `market_data` in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ac9d51390083288556f0131204f57c