### PR TITLE
chore: remove obsolete streamlit config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ Thumbs.db
 token.json
 .vscode/
 .idea/
+
+.streamlit/

--- a/data_pipeline/.streamlit/secrets.toml
+++ b/data_pipeline/.streamlit/secrets.toml
@@ -1,3 +1,0 @@
-# Streamlit secrets
-# Populate DATABASE_URL with the connection string to your hosted database
-DATABASE_URL = "postgresql://user:password@host:5432/database"


### PR DESCRIPTION
## Summary
- remove legacy Streamlit secrets
- ignore all `.streamlit/` directories

## Testing
- `rg -i "streamlit"`
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_b_68acb425bed883289df14e7d895f5bfd