### PR TITLE
Add missing StringIO import to analyse_db

### DIFF
--- a/data_pipeline/analyse_db.py
+++ b/data_pipeline/analyse_db.py
@@ -1,4 +1,4 @@
-import io
+from io import StringIO
 import logging
 import pandas as pd
 from sqlalchemy import create_engine


### PR DESCRIPTION
## Summary
- fix missing StringIO import in `analyse_db.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68acb752e3f88328a1baffd606c44413