### PR TITLE
Add FastAPI API and tests for pipeline interaction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+
+CMD ["uvicorn", "web.api:app", "--host", "0.0.0.0", "--port", "80"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ SQLAlchemy==2.0.41
 google-auth==2.40.3
 google-auth-oauthlib==1.2.2
 google-api-python-client==2.175.0
+fastapi==0.111.0
+uvicorn==0.30.1
 
 # Optional extras
 # investpy==1.0.8        # alternative data source

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,70 @@
+from fastapi.testclient import TestClient
+from web.api import app
+
+client = TestClient(app)
+
+
+def test_health_endpoint():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_compute_factors_endpoint():
+    payload = {
+        "data": [
+            {
+                "Date": "2023-07-01",
+                "Ticker": "ADV.L",
+                "Open": 100,
+                "High": 110,
+                "Low": 90,
+                "Close": 105,
+                "Volume": 1000,
+                "returnOnEquity": 0.2,
+                "profitMargins": 0.15,
+                "priceToBook": 1.8,
+                "trailingPE": 12.0,
+                "marketCap": 2000000,
+                "grossMargins": 0.3,
+                "operatingMargins": 0.2,
+                "forwardPE": 11.5,
+                "priceToSalesTrailing12Months": 2.0,
+                "debtToEquity": 0.4,
+                "currentRatio": 1.2,
+                "quickRatio": 1.1,
+                "dividendYield": 0.03,
+                "beta": 1.05,
+                "averageVolume": 1000
+            },
+            {
+                "Date": "2023-07-02",
+                "Ticker": "ADV.L",
+                "Open": 101,
+                "High": 111,
+                "Low": 91,
+                "Close": 106,
+                "Volume": 1100,
+                "returnOnEquity": 0.2,
+                "profitMargins": 0.15,
+                "priceToBook": 1.8,
+                "trailingPE": 12.0,
+                "marketCap": 2000000,
+                "grossMargins": 0.3,
+                "operatingMargins": 0.2,
+                "forwardPE": 11.5,
+                "priceToSalesTrailing12Months": 2.0,
+                "debtToEquity": 0.4,
+                "currentRatio": 1.2,
+                "quickRatio": 1.1,
+                "dividendYield": 0.03,
+                "beta": 1.05,
+                "averageVolume": 1000
+            }
+        ]
+    }
+    response = client.post("/compute-factors", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list) and len(data) == 2
+    assert "factor_composite" in data[0]

--- a/web/api.py
+++ b/web/api.py
@@ -1,0 +1,31 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import pandas as pd
+from data_pipeline.compute_factors import compute_factors
+
+app = FastAPI()
+
+
+class FactorsRequest(BaseModel):
+    data: list[dict]
+
+
+@app.get("/health")
+def health() -> dict:
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
+@app.post("/compute-factors")
+def compute_factors_endpoint(payload: FactorsRequest) -> list[dict]:
+    """Compute financial factors for the provided dataset.
+
+    Parameters
+    ----------
+    payload : FactorsRequest
+        Request body containing a list of dictionaries with price and
+        fundamental fields.
+    """
+    df = pd.DataFrame(payload.data)
+    result_df = compute_factors(df)
+    return result_df.to_dict(orient="records")


### PR DESCRIPTION
## Summary
- add FastAPI app exposing `/health` and `/compute-factors` endpoints
- include FastAPI and Uvicorn dependencies
- provide Dockerfile running the API with uvicorn
- cover API responses with new tests

## Testing
- `pip install fastapi==0.111.0 uvicorn==0.30.1` *(fails: Could not find a version that satisfies the requirement fastapi==0.111.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_b_68acb71824dc83289a2d456abe872668