### PR TITLE
docs: add ECS deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,40 @@ CACHE_S3_PREFIX=your/prefix
 
 Load the variables with a tool like [`python-dotenv`](https://github.com/theskumar/python-dotenv) or by running `export $(grep -v '^#' .env | xargs)`.
 
+### Deploying to AWS ECS
+
+#### Prerequisites
+
+- Docker installed and available on your machine.
+- AWS CLI configured with credentials and default region.
+- An Amazon ECR repository to store container images.
+- An ECS task-definition JSON template describing the service.
+
+#### Build and push the image
+
+```bash
+# Build the Docker image
+docker build -t $ECR_REPO_URI:latest .
+
+# Authenticate Docker to Amazon ECR and push the image
+aws ecr get-login-password --region $AWS_DEFAULT_REGION | \
+  docker login --username AWS --password-stdin $ECR_REPO_URI
+docker push $ECR_REPO_URI:latest
+```
+
+#### Launch or update the service
+
+Use the AWS CLI to register the task definition and update the ECS service:
+
+```bash
+aws ecs register-task-definition --cli-input-json file://task-definition.json
+aws ecs update-service --cluster $CLUSTER_NAME \
+  --service $SERVICE_NAME --force-new-deployment
+```
+
+#### Troubleshooting
+
+- **Networking** – verify that the service's subnets and security groups allow the necessary inbound and outbound traffic.
+- **IAM permissions** – ensure the task execution role can pull from ECR and access any required AWS services.
+- **Environment variables** – confirm that all required variables and secrets are provided in the task definition or ECS service configuration.
+


### PR DESCRIPTION
## Summary
- document prerequisites for ECS deployments
- add build, push and service update commands
- note common ECS troubleshooting areas

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68acb71616c8832882c1f11d266887d9