### PR TITLE
Add ECS Fargate deployment templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ token.json
 .idea/
 
 .streamlit/
+
+# Allow infrastructure JSON files
+!infra/**/*.json

--- a/infra/ecs/ecs-fargate.yaml
+++ b/infra/ecs/ecs-fargate.yaml
@@ -1,0 +1,139 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ECS Fargate deployment for EquityAlphaEngine
+
+Parameters:
+  VpcId:
+    Type: String
+    Description: VPC ID for ECS resources
+  SubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: Subnets for ECS tasks and load balancer
+  DesiredCount:
+    Type: Number
+    Default: 1
+    Description: Desired number of running tasks
+  ContainerImage:
+    Type: String
+    Description: ECR image for the application
+  ContainerPort:
+    Type: Number
+    Default: 8080
+    Description: Container port to expose
+  Cpu:
+    Type: Number
+    Default: 256
+    Description: Task CPU units
+  Memory:
+    Type: Number
+    Default: 512
+    Description: Task memory (MiB)
+
+Resources:
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+
+  TaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: equity-alpha-engine
+      Cpu: !Ref Cpu
+      Memory: !Ref Memory
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      ContainerDefinitions:
+        - Name: app
+          Image: !Ref ContainerImage
+          Essential: true
+          PortMappings:
+            - ContainerPort: !Ref ContainerPort
+          Environment:
+            - Name: ENV
+              Value: production
+
+  LoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow HTTP access to load balancer
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+
+  ServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow access from load balancer to tasks
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref ContainerPort
+          ToPort: !Ref ContainerPort
+          SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
+
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internet-facing
+      Subnets: !Ref SubnetIds
+      SecurityGroups:
+        - !Ref LoadBalancerSecurityGroup
+
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      VpcId: !Ref VpcId
+      Port: !Ref ContainerPort
+      Protocol: HTTP
+      TargetType: ip
+      HealthCheckPath: /
+
+  Listener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+
+  Service:
+    Type: AWS::ECS::Service
+    DependsOn: Listener
+    Properties:
+      Cluster: !Ref ECSCluster
+      DesiredCount: !Ref DesiredCount
+      LaunchType: FARGATE
+      TaskDefinition: !Ref TaskDefinition
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          Subnets: !Ref SubnetIds
+          SecurityGroups:
+            - !Ref ServiceSecurityGroup
+      LoadBalancers:
+        - ContainerName: app
+          ContainerPort: !Ref ContainerPort
+          TargetGroupArn: !Ref TargetGroup
+
+Outputs:
+  LoadBalancerDNSName:
+    Description: DNS name of the Application Load Balancer
+    Value: !GetAtt LoadBalancer.DNSName

--- a/infra/ecs/taskdef.json
+++ b/infra/ecs/taskdef.json
@@ -1,0 +1,24 @@
+{
+  "family": "equity-alpha-engine",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "123456789012.dkr.ecr.us-east-1.amazonaws.com/equity-alpha-engine:latest",
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,
+      "environment": [
+        {"name": "ENV", "value": "production"},
+        {"name": "LOG_LEVEL", "value": "info"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add ECS task definition JSON with CPU/memory, port mapping, and env variables
- provision ECS Fargate cluster/service and ALB via CloudFormation template
- allow infrastructure JSON files to be tracked

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68acb712d98483288c10d8fe876fe51f