### PR TITLE
Add Docker support and ignore configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Ignore Git metadata
+.git
+.gitignore
+.github
+
+# Exclude tests
+tests
+
+# Python caches and local artifacts
+__pycache__/
+*.py[cod]
+*.so
+*.log
+
+# Environment files
+.env
+.env.*
+
+# Build artifacts
+build/
+dist/
+*.egg-info/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Dockerfile for EquityAlphaEngine
+#
+# Required environment variables:
+#   QUANDL_API_KEY        Quandl API key for macroeconomic data
+#   DATABASE_URL          Database connection string
+#   AWS_ACCESS_KEY_ID     AWS credentials for S3 cache backend
+#   AWS_SECRET_ACCESS_KEY AWS credentials for S3 cache backend
+#   AWS_DEFAULT_REGION    Region for AWS resources
+#   CACHE_S3_BUCKET       S3 bucket used when CACHE_BACKEND=s3
+#   CACHE_S3_PREFIX       Prefix for cached data in S3 bucket
+#   MAX_THREADS           Optional: override default concurrency
+#
+# Build with:
+#   docker build -t equity-alpha-engine .
+#
+# Run with environment variables (e.g. via --env-file):
+#   docker run --rm --env-file .env equity-alpha-engine --years 10
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT ["python", "data_pipeline/market_data.py"]


### PR DESCRIPTION
## Summary
- Add Dockerfile to build an image for the data pipeline and document required environment variables
- Introduce .dockerignore to keep Git metadata, tests and build artefacts out of the Docker context

## Testing
- `pytest`
- `docker build -t equity-alpha-engine .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_b_68acb710f6cc832882cddc2da6d3b874