### PR TITLE
chore: switch Cloud Run deployment to Artifact Registry

### DIFF
--- a/infra/gcp/README.md
+++ b/infra/gcp/README.md
@@ -1,6 +1,7 @@
 # GCP Deployment
 
 This directory contains configuration and scripts for deploying the EquityAlphaEngine to [Cloud Run](https://cloud.google.com/run).
+Container images are stored in an [Artifact Registry](https://cloud.google.com/artifact-registry) repository.
 
 ## Deploying
 
@@ -9,7 +10,11 @@ This directory contains configuration and scripts for deploying the EquityAlphaE
    gcloud auth login
    gcloud config set project <PROJECT_ID>
    ```
-2. Build and deploy using the provided script:
+2. Configure Docker to authenticate to Artifact Registry (replace REGION with your deploy region):
+   ```bash
+   gcloud auth configure-docker REGION-docker.pkg.dev
+   ```
+3. Build and deploy using the provided script. The script pushes the container image to the `AR_REPO` Artifact Registry repository in your project:
    ```bash
    cd infra/gcp
    ./deploy-cloud-run.sh

--- a/infra/gcp/cloudrun-service.yaml
+++ b/infra/gcp/cloudrun-service.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/PROJECT_ID/equity-alpha-engine:latest
+        - image: REGION-docker.pkg.dev/PROJECT_ID/AR_REPO/equity-alpha-engine:latest
           ports:
             - containerPort: 8080
       containerConcurrency: 80

--- a/infra/gcp/deploy-cloud-run.sh
+++ b/infra/gcp/deploy-cloud-run.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PROJECT_ID=${PROJECT_ID:-$(gcloud config get-value project)}
+GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT:-$(gcloud config get-value project)}
 REGION=${REGION:-us-central1}
 SERVICE_NAME=${SERVICE_NAME:-equity-alpha-engine}
-IMAGE="gcr.io/${PROJECT_ID}/${SERVICE_NAME}:latest"
+AR_REPO=${AR_REPO:-containers}
+IMAGE="${REGION}-docker.pkg.dev/${GOOGLE_CLOUD_PROJECT}/${AR_REPO}/${SERVICE_NAME}:latest"
 
 # Build container image using Cloud Build
 echo "Building image ${IMAGE}"


### PR DESCRIPTION
## Summary
- push Cloud Run images to Artifact Registry instead of gcr.io
- update Cloud Run service YAML for Artifact Registry
- document Artifact Registry setup and auth

## Testing
- `bash -c 'gcloud(){ echo gcloud "$@"; }; export -f gcloud; REGION=us-central1 GOOGLE_CLOUD_PROJECT=myproj AR_REPO=myrepo SERVICE_NAME=eae ./infra/gcp/deploy-cloud-run.sh'`
- `bash -c 'gcloud(){ echo gcloud "$@"; }; export -f gcloud; gcloud run services replace infra/gcp/cloudrun-service.yaml --region us-central1'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b054bcee3c8328981bf2e45f32a3c0