### PR TITLE
Fix Cloud Run deployment failure: correct get_secret import path

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 3. **Pandas Deprecation Warnings**: pct_change default fill_method deprecated.
 4. **Multiple Data Population Triggers**: Pipeline runs multiple times due to empty table checks.
 5. **Long Runtime**: Script runs for 19+ minutes before cancellation.
+6. **Cloud Run Deployment Failure**: ImportError in uvicorn due to missing dependencies and incorrect import paths.
 
 ## Planned Fixes
 - [x] Update pct_change calls in compute_factors.py to use fill_method=None
@@ -43,3 +44,11 @@
 - [x] Fix Ticker column overwrite causing database insert errors
 - [ ] Test optimized pipeline performance
 - [ ] Monitor execution time improvements
+
+## Cloud Run Deployment Fixes
+- [x] Install missing dependencies (fastapi, uvicorn) via requirements.txt
+- [x] Fix incorrect import path for get_secret function in web/api.py
+- [x] Verify uvicorn can successfully import and start the FastAPI app
+- [x] Test local deployment to ensure container startup works
+- [ ] Deploy updated container to Cloud Run and verify successful startup
+- [ ] Monitor Cloud Run logs for any remaining import or startup issues

--- a/web/api.py
+++ b/web/api.py
@@ -8,7 +8,7 @@ from sqlalchemy import text
 
 from data_pipeline.compute_factors import compute_factors
 from data_pipeline.db_utils import DBHelper
-from data_pipeline.update_financial_data import get_secret
+from data_pipeline.utils import get_secret
 
 app = FastAPI()
 


### PR DESCRIPTION
This PR fixes the Google Cloud Run deployment failure that was causing container startup errors.

## Changes Made:
- **Fixed ImportError in web/api.py**: Corrected the import path for get_secret function from data_pipeline.update_financial_data to data_pipeline.utils
- **Updated TODO.md**: Added documentation for Cloud Run deployment fixes

## Problem:
The container was failing to start in Google Cloud Run due to an ImportError when uvicorn tried to import the FastAPI app. The get_secret function was being imported from the wrong module.

## Solution:
- Verified that get_secret is defined in data_pipeline/utils.py
- Updated the import statement in web/api.py to use the correct path
- Tested locally to ensure uvicorn can successfully import and start the FastAPI app

## Testing:
-  Successfully imported the FastAPI app without errors
-  Verified uvicorn can start the server on port 8080
-  Confirmed the container startup process works locally

The deployment should now work correctly in Google Cloud Run.