### PR TITLE
Remove Streamlit from requirements.txt for v2.0.1 release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,7 @@ google-cloud-secret-manager==2.16.1
 fastapi==0.111.0
 uvicorn==0.30.1
 
-# Streamlit for dashboard
-streamlit==1.28.1
+
 
 # Add urllib3 for URL encoding support
 urllib3==2.0.4


### PR DESCRIPTION
This PR removes the Streamlit dependency from requirements.txt as it is installed separately in the Dockerfile.streamlit. This resolves dependency conflicts and ensures proper deployment.